### PR TITLE
Idiomatic base bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "emf-core-base-rs",
     "emf-core-base-rs-bare",
     "emf-core-base-rs-ffi",
     "emf-core-base-rs-ffi-bare",

--- a/emf-core-base-rs-bare/src/base_interface.rs
+++ b/emf-core-base-rs-bare/src/base_interface.rs
@@ -708,6 +708,18 @@ impl<'a> AsRef<ffi::BaseInterface> for BaseInterface<'a> {
     }
 }
 
+impl<'a> FFIObject<&'a ffi::BaseInterface> for BaseInterface<'a> {
+    fn as_native(&self) -> &'a ffi::BaseInterface {
+        self.interface
+    }
+
+    unsafe fn from_native(val: &'a ffi::BaseInterface) -> Self {
+        Self {
+            interface: val,
+        }
+    }
+}
+
 impl<'a> FFIObject<ModuleInterface> for BaseInterface<'a> {
     fn as_native(&self) -> ModuleInterface {
         ModuleInterface {

--- a/emf-core-base-rs-bare/src/base_interface.rs
+++ b/emf-core-base-rs-bare/src/base_interface.rs
@@ -714,9 +714,7 @@ impl<'a> FFIObject<&'a ffi::BaseInterface> for BaseInterface<'a> {
     }
 
     unsafe fn from_native(val: &'a ffi::BaseInterface) -> Self {
-        Self {
-            interface: val,
-        }
+        Self { interface: val }
     }
 }
 

--- a/emf-core-base-rs-bare/src/lib.rs
+++ b/emf-core-base-rs-bare/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! # Note
 //!
-//! This crate is intended by the implementors of the `emf-core-base` interface.
+//! This crate is intended to be used by the implementors of the `emf-core-base` interface.
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 

--- a/emf-core-base-rs-ffi-bare/src/lib.rs
+++ b/emf-core-base-rs-ffi-bare/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! # Note
 //!
-//! This crate is intended by the implementors of the `emf-core-base` interface.
+//! This crate is intended to be used by the implementors of the `emf-core-base` interface.
 
 pub use boolean::Bool;
 pub use fn_id::FnId;

--- a/emf-core-base-rs/Cargo.toml
+++ b/emf-core-base-rs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "emf-core-base-rs"
+version = "0.1.0"
+authors = ["Gabriel Borrelli <gabriel.borrelli@nanoshellsoft.com>"]
+edition = "2018"
+description = "Rust bindings to the emf-core-base interface"
+license = "MIT OR Apache-2.0"
+categories = ["game-development"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["global_api"]
+global_api = ["emf-core-base-rs-bare/global_api", "emf-core-base-rs-ffi/global_api"]
+
+[dependencies]
+emf-core-base-rs-bare = { version = "0.1.0", path = "../emf-core-base-rs-bare" }
+emf-core-base-rs-ffi = { version = "0.1.0", path = "../emf-core-base-rs-ffi" }

--- a/emf-core-base-rs/src/bindings.rs
+++ b/emf-core-base-rs/src/bindings.rs
@@ -1,0 +1,68 @@
+//! Utilities the manage the binding to the interface.
+
+use crate::{ffi, BaseInterface, FFIObject};
+use ffi::fn_ptr::SysGetFunctionFn;
+use ffi::{BaseT, InterfaceBinding};
+
+/// Initialize ffi bindings.
+pub mod ffi_bindings {
+    #[cfg(feature = "global_api")]
+    pub use emf_core_base_rs_ffi::initialize_base_binding as initialize_ffi_base_binding;
+    pub use emf_core_base_rs_ffi::InterfaceLoader as FFIInterfaceLoader;
+}
+
+/// A trait to initialize a binding object.
+pub trait InterfaceLoader<'a> {
+    /// Type of the binding object.
+    type BindingT: InterfaceBinding;
+
+    /// Initializes the binding object.
+    ///
+    /// # Safety
+    ///
+    /// The parameter `get_function_fn` must be able to accept `base_module`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if it can not initialize the binding
+    unsafe fn initialize(
+        base_module: *mut BaseT,
+        get_function_fn: SysGetFunctionFn,
+    ) -> Self::BindingT;
+}
+
+/// Initializes the binding to the `emf-core-base` interface.
+///
+/// Calling this is necessary if the user wishes to use a function defined
+/// by the `emf-core-base` interface. Alternatively, a local object implementing the
+/// [InterfaceLoader] trait, such as [BaseInterface], can be used.
+///
+/// # Safety
+///
+/// The parameter `get_function_fn` must be able to accept `base_module`.
+///
+/// # Panics
+///
+/// This function panics if it can not initialize the binding
+#[cfg(feature = "global_api")]
+pub unsafe fn initialize_base_binding(
+    base_module: *mut BaseT,
+    get_function_fn: SysGetFunctionFn,
+) -> BaseInterface<'static> {
+    let bindings = ffi_bindings::initialize_ffi_base_binding(base_module, get_function_fn);
+    BaseInterface::from_native(bindings)
+}
+
+impl<'a> InterfaceLoader<'a> for BaseInterface<'a> {
+    type BindingT = Self;
+
+    unsafe fn initialize(
+        base_module: *mut BaseT,
+        get_function_fn: SysGetFunctionFn,
+    ) -> Self::BindingT {
+        use ffi_bindings::FFIInterfaceLoader;
+
+        let bindings = ffi::BaseInterface::initialize(base_module, get_function_fn);
+        BaseInterface::from_native(bindings)
+    }
+}

--- a/emf-core-base-rs/src/lib.rs
+++ b/emf-core-base-rs/src/lib.rs
@@ -1,7 +1,9 @@
-pub use emf_core_base_rs_bare;
+//! Idiomatic rust bindings for the `emf-core-base` interface.
+//!
+//! This crate provides idiomatic wrappers of the function and type definitions specified by the
+//! [emf-core-base](https://fimoengine.github.io/emf/emf-core-base/index.html) interface.
+//! No implementation for those functions is provided.
 
-pub mod ffi_bindings {
-    #[cfg(feature = "global_api")]
-    pub use emf_core_base_rs_ffi::initialize_base_binding;
-    pub use emf_core_base_rs_ffi::InterfaceLoader;
-}
+pub use emf_core_base_rs_bare::*;
+
+pub mod bindings;

--- a/emf-core-base-rs/src/lib.rs
+++ b/emf-core-base-rs/src/lib.rs
@@ -1,0 +1,7 @@
+pub use emf_core_base_rs_bare;
+
+pub mod ffi_bindings {
+    #[cfg(feature = "global_api")]
+    pub use emf_core_base_rs_ffi::initialize_base_binding;
+    pub use emf_core_base_rs_ffi::InterfaceLoader;
+}


### PR DESCRIPTION
Adds the `emf-core-base-rs` crate which combines the `emf-core-base-rs-bare` and `emf-core-base-rs-ffi` crates.