### PR TITLE
Revert Bool to repr(i8)

### DIFF
--- a/emf-core-base-rs-ffi-bare/src/boolean.rs
+++ b/emf-core-base-rs-ffi-bare/src/boolean.rs
@@ -2,8 +2,7 @@
 #![allow(dead_code)]
 
 /// An enum describing a boolean value.
-// TODO: Replace with `#[repr(i8)]` once https://github.com/rust-lang/rust/issues/80556 is fixed.
-#[repr(u8)]
+#[repr(i8)]
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum Bool {
     False = 0,


### PR DESCRIPTION
Revert the representation of the `Bool` type from `repr(u8)` to `repr(i8)`.