### PR TITLE
Implement emf-core-base-rs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: rustup component add rustfmt
+          components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -76,7 +76,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - run: rustup component add clippy
+          components: clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 
 members = [
+    "emf-core-base-rs",
     "emf-core-base-rs-ffi",
 ]

--- a/emf-core-base-rs-ffi/src/cbase.rs
+++ b/emf-core-base-rs-ffi/src/cbase.rs
@@ -118,6 +118,12 @@ pub trait CBaseBinding: SysBinding + VersionBinding + LibraryBinding + ModuleBin
 
     /// Returns a handle to the interface.
     fn base_module(&self) -> Option<NonNull<CBase>>;
+
+    /// Returns a fn pointer to the `has_function` fn.
+    fn fetch_has_function_fn(&self) -> sys_api::HasFunctionFn;
+
+    /// Returns a fn pointer to the `get_function` fn.
+    fn fetch_get_function_fn(&self) -> sys_api::GetFunctionFn;
 }
 
 impl CBaseBinding for CBaseInterface {
@@ -129,5 +135,15 @@ impl CBaseBinding for CBaseInterface {
     #[inline]
     fn base_module(&self) -> Option<NonNull<CBase>> {
         self.base_module
+    }
+
+    #[inline]
+    fn fetch_has_function_fn(&self) -> sys_api::HasFunctionFn {
+        self.sys_has_function_fn
+    }
+
+    #[inline]
+    fn fetch_get_function_fn(&self) -> sys_api::GetFunctionFn {
+        self.sys_get_function_fn
     }
 }

--- a/emf-core-base-rs-ffi/src/extensions/unwind_internal.rs
+++ b/emf-core-base-rs-ffi/src/extensions/unwind_internal.rs
@@ -1,7 +1,7 @@
 //! The `unwind_internal` extension.
 use crate::collections::NonNullConst;
 use crate::version::ReleaseType;
-use crate::{CBase, CBaseBinding};
+use crate::{CBase, CBaseBinding, TypeWrapper};
 use std::ptr::NonNull;
 
 /// Name of the extension.
@@ -34,21 +34,39 @@ pub struct Context {
     _dummy: [u8; 0],
 }
 
-pub type ShutdownFn = unsafe extern "C" fn(context: Option<NonNull<Context>>) -> !;
-pub type PanicFn =
-    unsafe extern "C" fn(context: Option<NonNull<Context>>, error: Option<NonNullConst<u8>>) -> !;
+pub type ShutdownFn =
+    TypeWrapper<unsafe extern "C-unwind" fn(context: Option<NonNull<Context>>) -> !>;
+pub type PanicFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        context: Option<NonNull<Context>>,
+        error: Option<NonNullConst<u8>>,
+    ) -> !,
+>;
 
-pub type SetContextFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, context: Option<NonNull<Context>>);
-pub type GetContextFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> Option<NonNull<Context>>;
-pub type SetShutdownFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, shutdown_fn: Option<ShutdownFn>);
-pub type GetShutdownFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> Option<ShutdownFn>;
-pub type SetPanicFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, shutdown_fn: Option<PanicFn>);
-pub type GetPanicFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> Option<PanicFn>;
+pub type SetContextFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        context: Option<NonNull<Context>>,
+    ),
+>;
+pub type GetContextFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> Option<NonNull<Context>>,
+>;
+pub type SetShutdownFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        shutdown_fn: Option<ShutdownFn>,
+    ),
+>;
+pub type GetShutdownFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> Option<ShutdownFn>,
+>;
+pub type SetPanicFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>, shutdown_fn: Option<PanicFn>),
+>;
+pub type GetPanicFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> Option<PanicFn>,
+>;
 
 /// Extension interface.
 #[repr(C)]
@@ -172,7 +190,8 @@ where
     }
 }
 
-pub type GetUnwindInternalInterfaceFn =
-    unsafe extern "C" fn(
+pub type GetUnwindInternalInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         base_module: Option<NonNull<CBase>>,
-    ) -> NonNullConst<UnwindInternalInterface>;
+    ) -> NonNullConst<UnwindInternalInterface>,
+>;

--- a/emf-core-base-rs-ffi/src/lib.rs
+++ b/emf-core-base-rs-ffi/src/lib.rs
@@ -7,9 +7,11 @@
 //!
 //! Most of the interface is not thread-safe and must be manually synchronised with
 //! [sys::api::SysBinding::lock] or [sys::api::SysBinding::try_lock].
+#![feature(c_unwind)]
 mod boolean;
 mod cbase;
 mod fn_id;
+mod type_wrapper;
 
 #[cfg(feature = "init")]
 mod init;
@@ -25,14 +27,7 @@ pub mod version;
 pub use boolean::Bool;
 pub use cbase::{CBase, CBaseBinding, CBaseFn, CBaseInterface, CBASE_INTERFACE_NAME};
 pub use fn_id::FnId;
+pub use type_wrapper::TypeWrapper;
 
 #[cfg(feature = "init")]
 pub use init::CBaseLoader;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/emf-core-base-rs-ffi/src/library/api.rs
+++ b/emf-core-base-rs-ffi/src/library/api.rs
@@ -6,94 +6,123 @@ use crate::library::library_loader::LibraryLoaderInterface;
 use crate::library::{
     Error, InternalHandle, LibraryHandle, LibraryType, LoaderHandle, OSPathChar, Symbol,
 };
-use crate::{Bool, CBase, CBaseFn, CBaseInterface};
+use crate::{Bool, CBase, CBaseFn, CBaseInterface, TypeWrapper};
 use std::ffi::c_void;
 use std::ptr::NonNull;
 
-pub type RegisterLoaderFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    loader: NonNullConst<LibraryLoaderInterface>,
-    lib_type: NonNullConst<LibraryType>,
-) -> Result<LoaderHandle, Error>;
+pub type RegisterLoaderFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        loader: NonNullConst<LibraryLoaderInterface>,
+        lib_type: NonNullConst<LibraryType>,
+    ) -> Result<LoaderHandle, Error>,
+>;
 
-pub type UnregisterLoaderFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LoaderHandle,
-) -> Result<i8, Error>;
-
-pub type GetLoaderInterfaceFn =
-    unsafe extern "C" fn(
+pub type UnregisterLoaderFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         base_module: Option<NonNull<CBase>>,
         handle: LoaderHandle,
-    ) -> Result<NonNullConst<LibraryLoaderInterface>, Error>;
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetLoaderHandleFromTypeFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    lib_type: NonNullConst<LibraryType>,
-) -> Result<LoaderHandle, Error>;
+pub type GetLoaderInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LoaderHandle,
+    ) -> Result<NonNullConst<LibraryLoaderInterface>, Error>,
+>;
 
-pub type GetLoaderHandleFromLibraryFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LibraryHandle,
-) -> Result<LoaderHandle, Error>;
+pub type GetLoaderHandleFromTypeFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        lib_type: NonNullConst<LibraryType>,
+    ) -> Result<LoaderHandle, Error>,
+>;
 
-pub type GetNumLoadersFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> usize;
+pub type GetLoaderHandleFromLibraryFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LibraryHandle,
+    ) -> Result<LoaderHandle, Error>,
+>;
 
-pub type LibraryExistsFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, handle: LibraryHandle) -> Bool;
+pub type GetNumLoadersFn =
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> usize>;
 
-pub type TypeExistsFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    lib_type: NonNullConst<LibraryType>,
-) -> Bool;
+pub type LibraryExistsFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>, handle: LibraryHandle) -> Bool,
+>;
 
-pub type GetLibraryTypesFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    buffer: NonNull<MutSpan<LibraryType>>,
-) -> Result<usize, Error>;
+pub type TypeExistsFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        lib_type: NonNullConst<LibraryType>,
+    ) -> Bool,
+>;
+
+pub type GetLibraryTypesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        buffer: NonNull<MutSpan<LibraryType>>,
+    ) -> Result<usize, Error>,
+>;
 
 pub type CreateLibraryHandleFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> LibraryHandle;
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> LibraryHandle>;
 
-pub type RemoveLibraryHandleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LibraryHandle,
-) -> Result<i8, Error>;
+pub type RemoveLibraryHandleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LibraryHandle,
+    ) -> Result<i8, Error>,
+>;
 
-pub type LinkLibraryFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LibraryHandle,
-    loader: LoaderHandle,
-    internal: InternalHandle,
-) -> Result<i8, Error>;
+pub type LinkLibraryFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LibraryHandle,
+        loader: LoaderHandle,
+        internal: InternalHandle,
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetInternalLibraryHandleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LibraryHandle,
-) -> Result<InternalHandle, Error>;
+pub type GetInternalLibraryHandleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LibraryHandle,
+    ) -> Result<InternalHandle, Error>,
+>;
 
-pub type LoadFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    loader: LoaderHandle,
-    path: NonNullConst<OSPathChar>,
-) -> Result<LibraryHandle, Error>;
+pub type LoadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        loader: LoaderHandle,
+        path: NonNullConst<OSPathChar>,
+    ) -> Result<LibraryHandle, Error>,
+>;
 
-pub type UnloadFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LibraryHandle,
-) -> Result<i8, Error>;
+pub type UnloadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LibraryHandle,
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetDataSymbolFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LibraryHandle,
-    symbol: NonNullConst<u8>,
-) -> Result<Symbol<NonNullConst<c_void>>, Error>;
+pub type GetDataSymbolFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LibraryHandle,
+        symbol: NonNullConst<u8>,
+    ) -> Result<Symbol<NonNullConst<c_void>>, Error>,
+>;
 
-pub type GetFunctionSymbolFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: LibraryHandle,
-    symbol: NonNullConst<u8>,
-) -> Result<Symbol<CBaseFn>, Error>;
+pub type GetFunctionSymbolFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: LibraryHandle,
+        symbol: NonNullConst<u8>,
+    ) -> Result<Symbol<CBaseFn>, Error>,
+>;
 
 /// Helper trait for using the library api.
 pub trait LibraryBinding {

--- a/emf-core-base-rs-ffi/src/library/library_loader.rs
+++ b/emf-core-base-rs-ffi/src/library/library_loader.rs
@@ -3,7 +3,7 @@
 //! Any object that can be wrapped into a [LibraryLoaderInterface] can be used as a library loader.
 use crate::collections::{NonNullConst, Result};
 use crate::library::{Error, InternalHandle, OSPathChar, Symbol};
-use crate::CBaseFn;
+use crate::{CBaseFn, TypeWrapper};
 use std::ffi::c_void;
 #[cfg(windows)]
 use std::os::windows::raw::HANDLE;
@@ -15,30 +15,39 @@ pub struct LibraryLoader {
     _dummy: [u8; 0],
 }
 
-pub type LoadFn = unsafe extern "C" fn(
-    loader: Option<NonNull<LibraryLoader>>,
-    path: NonNullConst<OSPathChar>,
-) -> Result<InternalHandle, Error>;
+pub type LoadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<LibraryLoader>>,
+        path: NonNullConst<OSPathChar>,
+    ) -> Result<InternalHandle, Error>,
+>;
 
-pub type UnloadFn = unsafe extern "C" fn(
-    loader: Option<NonNull<LibraryLoader>>,
-    handle: InternalHandle,
-) -> Result<i8, Error>;
+pub type UnloadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<LibraryLoader>>,
+        handle: InternalHandle,
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetDataSymbolFn = unsafe extern "C" fn(
-    loader: Option<NonNull<LibraryLoader>>,
-    handle: InternalHandle,
-    name: NonNullConst<u8>,
-) -> Result<Symbol<NonNullConst<c_void>>, Error>;
+pub type GetDataSymbolFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<LibraryLoader>>,
+        handle: InternalHandle,
+        name: NonNullConst<u8>,
+    ) -> Result<Symbol<NonNullConst<c_void>>, Error>,
+>;
 
-pub type GetFnSymbolFn = unsafe extern "C" fn(
-    loader: Option<NonNull<LibraryLoader>>,
-    handle: InternalHandle,
-    name: NonNullConst<u8>,
-) -> Result<Symbol<CBaseFn>, Error>;
+pub type GetFnSymbolFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<LibraryLoader>>,
+        handle: InternalHandle,
+        name: NonNullConst<u8>,
+    ) -> Result<Symbol<CBaseFn>, Error>,
+>;
 
-pub type GetInternalInterfaceFn =
-    unsafe extern "C" fn(loader: Option<NonNull<LibraryLoader>>) -> NonNullConst<c_void>;
+pub type GetInternalInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(loader: Option<NonNull<LibraryLoader>>) -> NonNullConst<c_void>,
+>;
 
 /// Interface of a library loader.
 #[repr(C)]
@@ -210,24 +219,30 @@ pub type NativeLibraryHandle = NativeLibraryHandleUnix;
 pub type NativeLibraryHandle = NativeLibraryHandleWindows;
 
 #[cfg(unix)]
-pub type LoadExtFnUnix = unsafe extern "C" fn(
-    loader: Option<NonNull<LibraryLoader>>,
-    path: NonNullConst<OSPathChar>,
-    flags: i32,
-) -> Result<InternalHandle, Error>;
+pub type LoadExtFnUnix = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<LibraryLoader>>,
+        path: NonNullConst<OSPathChar>,
+        flags: i32,
+    ) -> Result<InternalHandle, Error>,
+>;
 
 #[cfg(windows)]
-pub type LoadExtFnWindows = unsafe extern "C" fn(
-    loader: Option<NonNull<LibraryLoader>>,
-    path: NonNullConst<OSPathChar>,
-    h_file: Option<NonNull<HANDLE>>,
-    flags: u32,
-) -> Result<InternalHandle, Error>;
+pub type LoadExtFnWindows = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<LibraryLoader>>,
+        path: NonNullConst<OSPathChar>,
+        h_file: Option<NonNull<HANDLE>>,
+        flags: u32,
+    ) -> Result<InternalHandle, Error>,
+>;
 
-pub type GetNativeHandleFn = unsafe extern "C" fn(
-    loader: Option<NonNull<LibraryLoader>>,
-    handle: InternalHandle,
-) -> Result<NativeLibraryHandle, Error>;
+pub type GetNativeHandleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<LibraryLoader>>,
+        handle: InternalHandle,
+    ) -> Result<NativeLibraryHandle, Error>,
+>;
 
 #[cfg(unix)]
 pub type LoadExtFn = LoadExtFnUnix;

--- a/emf-core-base-rs-ffi/src/module/api.rs
+++ b/emf-core-base-rs-ffi/src/module/api.rs
@@ -8,183 +8,242 @@ use crate::module::{
     Error, Interface, InterfaceDescriptor, InternalHandle, LoaderHandle, ModuleHandle, ModuleInfo,
     ModuleStatus, ModuleType,
 };
-use crate::{Bool, CBase, CBaseInterface};
+use crate::{Bool, CBase, CBaseInterface, TypeWrapper};
 use std::ptr::NonNull;
 
-pub type RegisterLoaderFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    loader: NonNullConst<ModuleLoaderInterface>,
-    mod_type: NonNullConst<ModuleType>,
-) -> Result<LoaderHandle, Error>;
+pub type RegisterLoaderFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        loader: NonNullConst<ModuleLoaderInterface>,
+        mod_type: NonNullConst<ModuleType>,
+    ) -> Result<LoaderHandle, Error>,
+>;
 
-pub type UnregisterLoaderFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    loader: LoaderHandle,
-) -> Result<i8, Error>;
-
-pub type GetLoaderInterfaceFn =
-    unsafe extern "C" fn(
+pub type UnregisterLoaderFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         base_module: Option<NonNull<CBase>>,
         loader: LoaderHandle,
-    ) -> Result<NonNullConst<ModuleLoaderInterface>, Error>;
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetLoaderHandleFromTypeFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    mod_type: NonNullConst<ModuleType>,
-) -> Result<LoaderHandle, Error>;
+pub type GetLoaderInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        loader: LoaderHandle,
+    ) -> Result<NonNullConst<ModuleLoaderInterface>, Error>,
+>;
 
-pub type GetLoaderHandleFromModuleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<LoaderHandle, Error>;
+pub type GetLoaderHandleFromTypeFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        mod_type: NonNullConst<ModuleType>,
+    ) -> Result<LoaderHandle, Error>,
+>;
 
-pub type GetNumModulesFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> usize;
+pub type GetLoaderHandleFromModuleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<LoaderHandle, Error>,
+>;
 
-pub type GetNumLoadersFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> usize;
+pub type GetNumModulesFn =
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> usize>;
+
+pub type GetNumLoadersFn =
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> usize>;
 
 pub type GetNumExportedInterfacesFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> usize;
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> usize>;
 
-pub type ModuleExistsFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, handle: ModuleHandle) -> Bool;
+pub type ModuleExistsFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>, handle: ModuleHandle) -> Bool,
+>;
 
-pub type TypeExistsFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    mod_type: NonNullConst<ModuleType>,
-) -> Bool;
+pub type TypeExistsFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        mod_type: NonNullConst<ModuleType>,
+    ) -> Bool,
+>;
 
-pub type ExportedInterfaceExistsFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Bool;
+pub type ExportedInterfaceExistsFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Bool,
+>;
 
-pub type GetModulesFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    buffer: NonNull<MutSpan<ModuleInfo>>,
-) -> Result<usize, Error>;
+pub type GetModulesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        buffer: NonNull<MutSpan<ModuleInfo>>,
+    ) -> Result<usize, Error>,
+>;
 
-pub type GetModuleTypesFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    buffer: NonNull<MutSpan<ModuleType>>,
-) -> Result<usize, Error>;
+pub type GetModuleTypesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        buffer: NonNull<MutSpan<ModuleType>>,
+    ) -> Result<usize, Error>,
+>;
 
-pub type GetExportedInterfacesFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    buffer: NonNull<MutSpan<InterfaceDescriptor>>,
-) -> Result<usize, Error>;
+pub type GetExportedInterfacesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        buffer: NonNull<MutSpan<InterfaceDescriptor>>,
+    ) -> Result<usize, Error>,
+>;
 
-pub type GetExportedInterfaceHandleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Result<ModuleHandle, Error>;
+pub type GetExportedInterfaceHandleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Result<ModuleHandle, Error>,
+>;
 
 pub type CreateModuleHandleFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> ModuleHandle;
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> ModuleHandle>;
 
-pub type RemoveModuleHandleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<i8, Error>;
-
-pub type LinkModuleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-    loader: LoaderHandle,
-    internal: InternalHandle,
-) -> Result<i8, Error>;
-
-pub type GetInternalModuleHandleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<InternalHandle, Error>;
-
-pub type AddModuleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    loader: LoaderHandle,
-    path: NonNullConst<OSPathChar>,
-) -> Result<ModuleHandle, Error>;
-
-pub type RemoveModuleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<i8, Error>;
-
-pub type LoadFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<i8, Error>;
-
-pub type UnloadFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<i8, Error>;
-
-pub type InitializeFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<i8, Error>;
-
-pub type TerminateFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<i8, Error>;
-
-pub type AddDependencyFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Result<i8, Error>;
-
-pub type RemoveDependencyFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Result<i8, Error>;
-
-pub type ExportInterfaceFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Result<i8, Error>;
-
-pub type GetLoadDependenciesFn =
-    unsafe extern "C" fn(
+pub type RemoveModuleHandleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         base_module: Option<NonNull<CBase>>,
         handle: ModuleHandle,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetRuntimeDependenciesFn =
-    unsafe extern "C" fn(
+pub type LinkModuleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         base_module: Option<NonNull<CBase>>,
         handle: ModuleHandle,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+        loader: LoaderHandle,
+        internal: InternalHandle,
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetExportableInterfacesFn =
-    unsafe extern "C" fn(
+pub type GetInternalModuleHandleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         base_module: Option<NonNull<CBase>>,
         handle: ModuleHandle,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+    ) -> Result<InternalHandle, Error>,
+>;
 
-pub type FetchStatusFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<ModuleStatus, Error>;
+pub type AddModuleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        loader: LoaderHandle,
+        path: NonNullConst<OSPathChar>,
+    ) -> Result<ModuleHandle, Error>,
+>;
 
-pub type GetModulePathFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<NonNullConst<OSPathChar>, Error>;
+pub type RemoveModuleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetModuleInfoFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-) -> Result<NonNullConst<ModuleInfo>, Error>;
+pub type LoadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetInterfaceFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handle: ModuleHandle,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Result<Interface, Error>;
+pub type UnloadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<i8, Error>,
+>;
+
+pub type InitializeFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<i8, Error>,
+>;
+
+pub type TerminateFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<i8, Error>,
+>;
+
+pub type AddDependencyFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Result<i8, Error>,
+>;
+
+pub type RemoveDependencyFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Result<i8, Error>,
+>;
+
+pub type ExportInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Result<i8, Error>,
+>;
+
+pub type GetLoadDependenciesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
+
+pub type GetRuntimeDependenciesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
+
+pub type GetExportableInterfacesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
+
+pub type FetchStatusFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<ModuleStatus, Error>,
+>;
+
+pub type GetModulePathFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<NonNullConst<OSPathChar>, Error>,
+>;
+
+pub type GetModuleInfoFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+    ) -> Result<NonNullConst<ModuleInfo>, Error>,
+>;
+
+pub type GetInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handle: ModuleHandle,
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Result<Interface, Error>,
+>;
 
 /// Helper trait for using the module api.
 pub trait ModuleBinding {
@@ -240,7 +299,7 @@ pub trait ModuleBinding {
     ///
     /// The function is not thread-safe and crosses the ffi boundary.
     unsafe fn get_loader_interface(
-        &self,
+        &mut self,
         loader: LoaderHandle,
     ) -> Result<NonNullConst<ModuleLoaderInterface>, Error>;
 
@@ -794,7 +853,7 @@ impl ModuleBinding for CBaseInterface {
 
     #[inline]
     unsafe fn get_loader_interface(
-        &self,
+        &mut self,
         loader: LoaderHandle,
     ) -> Result<NonNullConst<ModuleLoaderInterface>, Error> {
         (self.module_get_loader_interface_fn)(self.base_module, loader)

--- a/emf-core-base-rs-ffi/src/module/module_loader.rs
+++ b/emf-core-base-rs-ffi/src/module/module_loader.rs
@@ -7,6 +7,7 @@ use crate::module::native_module::NativeModule;
 use crate::module::{
     Error, Interface, InterfaceDescriptor, InternalHandle, ModuleInfo, ModuleStatus,
 };
+use crate::TypeWrapper;
 use std::ffi::c_void;
 use std::ptr::NonNull;
 
@@ -16,77 +17,101 @@ pub struct ModuleLoader {
     _dummy: [u8; 0],
 }
 
-pub type AddModuleFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    path: NonNullConst<OSPathChar>,
-) -> Result<InternalHandle, Error>;
+pub type AddModuleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        path: NonNullConst<OSPathChar>,
+    ) -> Result<InternalHandle, Error>,
+>;
 
-pub type RemoveModuleFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<i8, Error>;
-
-pub type LoadFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<i8, Error>;
-
-pub type UnloadFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<i8, Error>;
-
-pub type InitializeFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<i8, Error>;
-
-pub type TerminateFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<i8, Error>;
-
-pub type FetchStatusFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<ModuleStatus, Error>;
-
-pub type GetInterfaceFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Result<Interface, Error>;
-
-pub type GetModuleInfoFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<NonNullConst<ModuleInfo>, Error>;
-
-pub type GetModulePathFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<NonNullConst<OSPathChar>, Error>;
-
-pub type GetLoadDependenciesFn =
-    unsafe extern "C" fn(
+pub type RemoveModuleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         loader: Option<NonNull<ModuleLoader>>,
         handle: InternalHandle,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetRuntimeDependenciesFn =
-    unsafe extern "C" fn(
+pub type LoadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         loader: Option<NonNull<ModuleLoader>>,
         handle: InternalHandle,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetExportableInterfacesFn =
-    unsafe extern "C" fn(
+pub type UnloadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         loader: Option<NonNull<ModuleLoader>>,
         handle: InternalHandle,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+    ) -> Result<i8, Error>,
+>;
 
-pub type GetInternalInterfaceFn =
-    unsafe extern "C" fn(loader: Option<NonNull<ModuleLoader>>) -> NonNullConst<c_void>;
+pub type InitializeFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<i8, Error>,
+>;
+
+pub type TerminateFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<i8, Error>,
+>;
+
+pub type FetchStatusFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<ModuleStatus, Error>,
+>;
+
+pub type GetInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Result<Interface, Error>,
+>;
+
+pub type GetModuleInfoFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<NonNullConst<ModuleInfo>, Error>,
+>;
+
+pub type GetModulePathFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<NonNullConst<OSPathChar>, Error>,
+>;
+
+pub type GetLoadDependenciesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
+
+pub type GetRuntimeDependenciesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
+
+pub type GetExportableInterfacesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
+
+pub type GetInternalInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(loader: Option<NonNull<ModuleLoader>>) -> NonNullConst<c_void>,
+>;
 
 /// Interface of a module loader.
 #[repr(C)]
@@ -469,17 +494,19 @@ impl ModuleLoaderBinding for ModuleLoaderInterface {
     }
 }
 
-pub type GetNativeModuleFn = unsafe extern "C" fn(
-    loader: Option<NonNull<ModuleLoader>>,
-    handle: InternalHandle,
-) -> Result<Option<NonNull<NativeModule>>, Error>;
+pub type GetNativeModuleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        loader: Option<NonNull<ModuleLoader>>,
+        handle: InternalHandle,
+    ) -> Result<Option<NonNull<NativeModule>>, Error>,
+>;
 
 /// Interface of a native module loader.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct NativeModuleLoaderInterface {
-    loader: NonNullConst<ModuleLoaderInterface>,
-    get_native_module_fn: GetNativeModuleFn,
+    pub loader: NonNullConst<ModuleLoaderInterface>,
+    pub get_native_module_fn: GetNativeModuleFn,
 }
 
 unsafe impl Send for NativeModuleLoaderInterface {}

--- a/emf-core-base-rs-ffi/src/module/native_module.rs
+++ b/emf-core-base-rs-ffi/src/module/native_module.rs
@@ -4,7 +4,7 @@
 use crate::collections::{ConstSpan, NonNullConst, Result};
 use crate::module::{Error, Interface, InterfaceDescriptor, ModuleInfo};
 use crate::sys::api::{GetFunctionFn, HasFunctionFn};
-use crate::CBase;
+use crate::{CBase, TypeWrapper};
 use std::ptr::NonNull;
 
 /// Opaque structure representing a native module.
@@ -13,41 +13,53 @@ pub struct NativeModule {
     _dummy: [u8; 0],
 }
 
-pub type LoadFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    has_function_fn: HasFunctionFn,
-    get_function_fn: GetFunctionFn,
-) -> Result<Option<NonNull<NativeModule>>, Error>;
+pub type LoadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        has_function_fn: HasFunctionFn,
+        get_function_fn: GetFunctionFn,
+    ) -> Result<Option<NonNull<NativeModule>>, Error>,
+>;
 
-pub type UnloadFn =
-    unsafe extern "C" fn(module: Option<NonNull<NativeModule>>) -> Result<i8, Error>;
+pub type UnloadFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(module: Option<NonNull<NativeModule>>) -> Result<i8, Error>,
+>;
 
-pub type InitializeFn =
-    unsafe extern "C" fn(module: Option<NonNull<NativeModule>>) -> Result<i8, Error>;
+pub type InitializeFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(module: Option<NonNull<NativeModule>>) -> Result<i8, Error>,
+>;
 
-pub type TerminateFn =
-    unsafe extern "C" fn(module: Option<NonNull<NativeModule>>) -> Result<i8, Error>;
+pub type TerminateFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(module: Option<NonNull<NativeModule>>) -> Result<i8, Error>,
+>;
 
-pub type GetInterfaceFn = unsafe extern "C" fn(
-    module: Option<NonNull<NativeModule>>,
-    interface: NonNullConst<InterfaceDescriptor>,
-) -> Result<Interface, Error>;
-
-pub type GetModuleInfoFn = unsafe extern "C" fn(
-    module: Option<NonNull<NativeModule>>,
-) -> Result<NonNullConst<ModuleInfo>, Error>;
-
-pub type GetLoadDependenciesFn = unsafe extern "C" fn() -> ConstSpan<InterfaceDescriptor>;
-
-pub type GetRuntimeDependenciesFn =
-    unsafe extern "C" fn(
+pub type GetInterfaceFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         module: Option<NonNull<NativeModule>>,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+        interface: NonNullConst<InterfaceDescriptor>,
+    ) -> Result<Interface, Error>,
+>;
 
-pub type GetExportableInterfacesFn =
-    unsafe extern "C" fn(
+pub type GetModuleInfoFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
         module: Option<NonNull<NativeModule>>,
-    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>;
+    ) -> Result<NonNullConst<ModuleInfo>, Error>,
+>;
+
+pub type GetLoadDependenciesFn =
+    TypeWrapper<unsafe extern "C-unwind" fn() -> ConstSpan<InterfaceDescriptor>>;
+
+pub type GetRuntimeDependenciesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        module: Option<NonNull<NativeModule>>,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
+
+pub type GetExportableInterfacesFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        module: Option<NonNull<NativeModule>>,
+    ) -> Result<ConstSpan<InterfaceDescriptor>, Error>,
+>;
 
 /// Interface of a native module.
 #[repr(C)]

--- a/emf-core-base-rs-ffi/src/sys/api.rs
+++ b/emf-core-base-rs-ffi/src/sys/api.rs
@@ -3,33 +3,45 @@
 //! The sys api is exposed by the [SysBinding] trait.
 use crate::collections::{NonNullConst, Optional};
 use crate::sys::sync_handler::SyncHandlerInterface;
-use crate::{Bool, CBase, CBaseFn, CBaseInterface, FnId};
+use crate::{Bool, CBase, CBaseFn, CBaseInterface, FnId, TypeWrapper};
 use std::ptr::NonNull;
 
-pub type ShutdownFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> !;
+pub type ShutdownFn =
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> !>;
 
-pub type PanicFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, error: Option<NonNullConst<u8>>) -> !;
+pub type PanicFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        error: Option<NonNullConst<u8>>,
+    ) -> !,
+>;
 
 pub type HasFunctionFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, id: FnId) -> Bool;
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>, id: FnId) -> Bool>;
 
-pub type GetFunctionFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>, id: FnId) -> Optional<CBaseFn>;
+pub type GetFunctionFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>, id: FnId) -> Optional<CBaseFn>,
+>;
 
-pub type LockFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>);
+pub type LockFn = TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>)>;
 
-pub type TryLockFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> Bool;
+pub type TryLockFn =
+    TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>) -> Bool>;
 
-pub type UnlockFn = unsafe extern "C" fn(base_module: Option<NonNull<CBase>>);
+pub type UnlockFn = TypeWrapper<unsafe extern "C-unwind" fn(base_module: Option<NonNull<CBase>>)>;
 
-pub type GetSyncHandlerFn =
-    unsafe extern "C" fn(base_module: Option<NonNull<CBase>>) -> NonNullConst<SyncHandlerInterface>;
+pub type GetSyncHandlerFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+    ) -> NonNullConst<SyncHandlerInterface>,
+>;
 
-pub type SetSyncHandlerFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    handler: Option<NonNullConst<SyncHandlerInterface>>,
-);
+pub type SetSyncHandlerFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        handler: Option<NonNullConst<SyncHandlerInterface>>,
+    ),
+>;
 
 /// Helper trait for using the sys api.
 pub trait SysBinding {
@@ -44,7 +56,7 @@ pub trait SysBinding {
     ///
     /// # Safety
     ///
-    /// The function is not thread-safe and crosses the ffi boundary.
+    /// The function crosses the ffi boundary.
     unsafe fn panic(&self, error: Option<NonNullConst<u8>>) -> !;
 
     /// Checks if a function is implemented.
@@ -55,7 +67,7 @@ pub trait SysBinding {
     ///
     /// # Safety
     ///
-    /// The function is not thread-safe and crosses the ffi boundary.
+    /// The function crosses the ffi boundary.
     unsafe fn has_function(&self, id: FnId) -> Bool;
 
     /// Fetches a function from the interface.
@@ -66,7 +78,7 @@ pub trait SysBinding {
     ///
     /// # Safety
     ///
-    /// The function is not thread-safe and crosses the ffi boundary.
+    /// The function crosses the ffi boundary.
     unsafe fn get_function(&self, id: FnId) -> Optional<CBaseFn>;
 
     /// Locks the interface.

--- a/emf-core-base-rs-ffi/src/sys/sync_handler.rs
+++ b/emf-core-base-rs-ffi/src/sys/sync_handler.rs
@@ -1,7 +1,7 @@
 //! Interface of a sync handler
 //!
 //! Any object that can be wrapped into a [SyncHandlerInterface] can be used as a sync handler.
-use crate::Bool;
+use crate::{Bool, TypeWrapper};
 use std::ptr::NonNull;
 
 /// Opaque structure representing a sync handler.
@@ -10,9 +10,10 @@ pub struct SyncHandler {
     _dummy: [u8; 0],
 }
 
-pub type LockFn = unsafe extern "C" fn(handler: Option<NonNull<SyncHandler>>);
-pub type TryLockFn = unsafe extern "C" fn(handler: Option<NonNull<SyncHandler>>) -> Bool;
-pub type UnlockFn = unsafe extern "C" fn(handler: Option<NonNull<SyncHandler>>);
+pub type LockFn = TypeWrapper<unsafe extern "C-unwind" fn(handler: Option<NonNull<SyncHandler>>)>;
+pub type TryLockFn =
+    TypeWrapper<unsafe extern "C-unwind" fn(handler: Option<NonNull<SyncHandler>>) -> Bool>;
+pub type UnlockFn = TypeWrapper<unsafe extern "C-unwind" fn(handler: Option<NonNull<SyncHandler>>)>;
 
 /// Interface of a sync handler.
 #[repr(C)]

--- a/emf-core-base-rs-ffi/src/type_wrapper.rs
+++ b/emf-core-base-rs-ffi/src/type_wrapper.rs
@@ -1,0 +1,124 @@
+/// Wrapper around a type.
+///
+/// Is currently used to implement traits on existing types.
+#[repr(transparent)]
+pub struct TypeWrapper<T>(pub T);
+
+// Impls for function pointers
+// Modified from https://doc.rust-lang.org/src/core/ptr/mod.rs.html#1484
+macro_rules! fnptr_impls_safety_abi {
+    ($FnTy: ty, $($Arg: ident),*) => {
+        impl<Ret, $($Arg),*> PartialEq for TypeWrapper<$FnTy> {
+            #[inline]
+            fn eq(&self, other: &Self) -> bool {
+                self.0 as usize == other.0 as usize
+            }
+        }
+
+        impl<Ret, $($Arg),*> Copy for TypeWrapper<$FnTy> {}
+
+        impl<Ret, $($Arg),*> Clone for TypeWrapper<$FnTy> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<Ret, $($Arg),*> Eq for TypeWrapper<$FnTy> {}
+
+        impl<Ret, $($Arg),*> PartialOrd for TypeWrapper<$FnTy> {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                (self.0 as usize).partial_cmp(&(other.0 as usize))
+            }
+        }
+
+        impl<Ret, $($Arg),*> Ord for TypeWrapper<$FnTy> {
+            #[inline]
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                (self.0 as usize).cmp(&(other.0 as usize))
+            }
+        }
+
+        impl<Ret, $($Arg),*> std::hash::Hash for TypeWrapper<$FnTy> {
+            fn hash<HH: std::hash::Hasher>(&self, state: &mut HH) {
+                state.write_usize(self.0 as usize)
+            }
+        }
+
+        impl<Ret, $($Arg),*> std::ops::Deref for TypeWrapper<$FnTy> {
+            type Target = $FnTy;
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl<Ret, $($Arg),*> std::ops::DerefMut for TypeWrapper<$FnTy> {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+
+        impl<Ret, $($Arg),*> std::fmt::Pointer for TypeWrapper<$FnTy> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                // HACK: The intermediate cast as usize is required for AVR
+                // so that the address space of the source function pointer
+                // is preserved in the final function pointer.
+                //
+                // https://github.com/avr-rust/rust/issues/143
+                std::fmt::Pointer::fmt(&(self.0 as usize as *const ()), f)
+            }
+        }
+
+        impl<Ret, $($Arg),*> std::fmt::Debug for TypeWrapper<$FnTy> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                // HACK: The intermediate cast as usize is required for AVR
+                // so that the address space of the source function pointer
+                // is preserved in the final function pointer.
+                //
+                // https://github.com/avr-rust/rust/issues/143
+                std::fmt::Pointer::fmt(&(self.0 as usize as *const ()), f)
+            }
+        }
+    }
+}
+
+macro_rules! fnptr_impls_args {
+    ($($Arg: ident),+) => {
+        fnptr_impls_safety_abi! { extern "Rust" fn($($Arg),+) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { extern "C" fn($($Arg),+) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { extern "C" fn($($Arg),+ , ...) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { extern "C-unwind" fn($($Arg),+) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { extern "C-unwind" fn($($Arg),+ , ...) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { unsafe extern "Rust" fn($($Arg),+) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { unsafe extern "C" fn($($Arg),+) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { unsafe extern "C" fn($($Arg),+ , ...) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { unsafe extern "C-unwind" fn($($Arg),+) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { unsafe extern "C-unwind" fn($($Arg),+ , ...) -> Ret, $($Arg),+ }
+    };
+    () => {
+        // No variadic functions with 0 parameters
+        fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
+        fnptr_impls_safety_abi! { extern "C" fn() -> Ret, }
+        fnptr_impls_safety_abi! { extern "C-unwind" fn() -> Ret, }
+        fnptr_impls_safety_abi! { unsafe extern "Rust" fn() -> Ret, }
+        fnptr_impls_safety_abi! { unsafe extern "C" fn() -> Ret, }
+        fnptr_impls_safety_abi! { unsafe extern "C-unwind" fn() -> Ret, }
+    };
+}
+
+fnptr_impls_args! {}
+fnptr_impls_args! { A }
+fnptr_impls_args! { A, B }
+fnptr_impls_args! { A, B, C }
+fnptr_impls_args! { A, B, C, D }
+fnptr_impls_args! { A, B, C, D, E }
+fnptr_impls_args! { A, B, C, D, E, F }
+fnptr_impls_args! { A, B, C, D, E, F, G }
+fnptr_impls_args! { A, B, C, D, E, F, G, H }
+fnptr_impls_args! { A, B, C, D, E, F, G, H, I }
+fnptr_impls_args! { A, B, C, D, E, F, G, H, I, J }
+fnptr_impls_args! { A, B, C, D, E, F, G, H, I, J, K }
+fnptr_impls_args! { A, B, C, D, E, F, G, H, I, J, K, L }

--- a/emf-core-base-rs-ffi/src/version/api.rs
+++ b/emf-core-base-rs-ffi/src/version/api.rs
@@ -3,101 +3,131 @@
 //! The version api is exposed by the [VersionBinding] trait.
 use crate::collections::{ConstSpan, MutSpan, NonNullConst, Result};
 use crate::version::{Error, ReleaseType, Version};
-use crate::{Bool, CBase, CBaseInterface};
+use crate::{Bool, CBase, CBaseInterface, TypeWrapper};
 use std::ptr::NonNull;
 
-pub type NewShortFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    major: i32,
-    minor: i32,
-    patch: i32,
-) -> Version;
+pub type NewShortFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        major: i32,
+        minor: i32,
+        patch: i32,
+    ) -> Version,
+>;
 
-pub type NewLongFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    major: i32,
-    minor: i32,
-    patch: i32,
-    release_type: ReleaseType,
-    release_number: i8,
-) -> Version;
+pub type NewLongFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+    ) -> Version,
+>;
 
-pub type NewFullFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    major: i32,
-    minor: i32,
-    patch: i32,
-    release_type: ReleaseType,
-    release_number: i8,
-    build: i64,
-) -> Version;
+pub type NewFullFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+        build: i64,
+    ) -> Version,
+>;
 
-pub type FromStringFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    buffer: NonNullConst<ConstSpan<u8>>,
-) -> Result<Version, Error>;
+pub type FromStringFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        buffer: NonNullConst<ConstSpan<u8>>,
+    ) -> Result<Version, Error>,
+>;
 
-pub type StringLengthShortFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    version: NonNullConst<Version>,
-) -> usize;
+pub type StringLengthShortFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        version: NonNullConst<Version>,
+    ) -> usize,
+>;
 
-pub type StringLengthLongFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    version: NonNullConst<Version>,
-) -> usize;
+pub type StringLengthLongFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        version: NonNullConst<Version>,
+    ) -> usize,
+>;
 
-pub type StringLengthFullFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    version: NonNullConst<Version>,
-) -> usize;
+pub type StringLengthFullFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        version: NonNullConst<Version>,
+    ) -> usize,
+>;
 
-pub type AsStringShortFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    version: NonNullConst<Version>,
-    buffer: NonNull<MutSpan<u8>>,
-) -> Result<usize, Error>;
+pub type AsStringShortFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, Error>,
+>;
 
-pub type AsStringLongFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    version: NonNullConst<Version>,
-    buffer: NonNull<MutSpan<u8>>,
-) -> Result<usize, Error>;
+pub type AsStringLongFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, Error>,
+>;
 
-pub type AsStringFullFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    version: NonNullConst<Version>,
-    buffer: NonNull<MutSpan<u8>>,
-) -> Result<usize, Error>;
+pub type AsStringFullFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, Error>,
+>;
 
-pub type StringIsValidFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    version_string: NonNullConst<ConstSpan<u8>>,
-) -> Bool;
+pub type StringIsValidFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        version_string: NonNullConst<ConstSpan<u8>>,
+    ) -> Bool,
+>;
 
-pub type CompareFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    lhs: NonNullConst<Version>,
-    rhs: NonNullConst<Version>,
-) -> i32;
+pub type CompareFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        lhs: NonNullConst<Version>,
+        rhs: NonNullConst<Version>,
+    ) -> i32,
+>;
 
-pub type CompareWeakFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    lhs: NonNullConst<Version>,
-    rhs: NonNullConst<Version>,
-) -> i32;
+pub type CompareWeakFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        lhs: NonNullConst<Version>,
+        rhs: NonNullConst<Version>,
+    ) -> i32,
+>;
 
-pub type CompareStrongFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    lhs: NonNullConst<Version>,
-    rhs: NonNullConst<Version>,
-) -> i32;
+pub type CompareStrongFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        lhs: NonNullConst<Version>,
+        rhs: NonNullConst<Version>,
+    ) -> i32,
+>;
 
-pub type IsCompatibleFn = unsafe extern "C" fn(
-    base_module: Option<NonNull<CBase>>,
-    lhs: NonNullConst<Version>,
-    rhs: NonNullConst<Version>,
-) -> Bool;
+pub type IsCompatibleFn = TypeWrapper<
+    unsafe extern "C-unwind" fn(
+        base_module: Option<NonNull<CBase>>,
+        lhs: NonNullConst<Version>,
+        rhs: NonNullConst<Version>,
+    ) -> Bool,
+>;
 
 /// Helper trait for using the version api.
 pub trait VersionBinding {

--- a/emf-core-base-rs/Cargo.toml
+++ b/emf-core-base-rs/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "emf-core-base-rs"
+version = "0.1.0"
+authors = ["Gabriel Borrelli <gabriel.borrelli@nanoshellsoft.com>"]
+edition = "2018"
+description = "Idiomatic Rust wrapper of the emf-core-base interface"
+license = "MIT OR Apache-2.0"
+categories = ["game-development"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["global_api", "init", "extensions_all"]
+global_api = ["init"]
+init = ["emf-core-base-rs-ffi/init"]
+extensions = ["emf-core-base-rs-ffi/extensions"]
+unwind_internal = ["extensions", "emf-core-base-rs-ffi/unwind_internal"]
+extensions_all = ["unwind_internal", "emf-core-base-rs-ffi/extensions_all"]
+
+[dependencies]
+backtrace = "0.3.56"
+emf-core-base-rs-ffi = { version = "0.1.0", path = "../emf-core-base-rs-ffi" }

--- a/emf-core-base-rs/src/cbase.rs
+++ b/emf-core-base-rs/src/cbase.rs
@@ -1,0 +1,897 @@
+use crate::ffi::collections::{ConstSpan, MutSpan, NonNullConst, Optional, Result};
+use crate::ffi::library::api::LibraryBinding;
+use crate::ffi::library::library_loader::LibraryLoaderInterface;
+use crate::ffi::module;
+use crate::ffi::module::api::ModuleBinding;
+use crate::ffi::module::module_loader::ModuleLoaderInterface;
+use crate::ffi::sys::api::SysBinding;
+use crate::ffi::sys::sync_handler::SyncHandlerInterface;
+use crate::ffi::version;
+use crate::ffi::version::api::VersionBinding;
+use crate::ffi::version::{Error, ReleaseType};
+use crate::ffi::{library, CBaseBinding};
+use crate::ffi::{Bool, CBaseInterface, FnId};
+use crate::fn_caster::FnCaster;
+use crate::library::LibraryAPI;
+use crate::module::ModuleAPI;
+use crate::sys::{SysAPI, SysAPIMin};
+use crate::version::{Version, VersionAPI};
+use std::cell::UnsafeCell;
+use std::ffi::{c_void, CStr};
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+/// Borrowed `emf-core-base` interface.
+#[derive(Debug)]
+pub struct CBaseRef<'interface> {
+    _interface: NonNullConst<CBaseInterface>,
+    _phantom: PhantomData<&'interface CBaseInterface>,
+}
+
+/// Owned `emf-core-base` interface.
+#[derive(Debug)]
+pub struct CBase<'interface> {
+    _interface: UnsafeCell<CBaseRef<'interface>>,
+}
+
+impl CBaseRef<'_> {
+    /// Constructs itself using the native interface.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe, as it enables bypassing the locking mechanism.
+    pub unsafe fn new(interface: NonNullConst<CBaseInterface>) -> Self {
+        Self {
+            _interface: interface,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'interface> CBase<'interface> {
+    /// Constructs itself using the borrowed interface.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe, as it enables bypassing the locking mechanism.
+    pub unsafe fn new(interface: CBaseRef<'interface>) -> Self {
+        Self {
+            _interface: UnsafeCell::new(interface),
+        }
+    }
+}
+
+/// A trait for providing information about the loaded interface.
+pub trait CBaseInterfaceInfo {
+    /// Type of the interface.
+    type Interface: CBaseBinding;
+
+    /// Returns the version of the interface.
+    fn interface_version(&self) -> Version;
+
+    /// Fetches the internal low-level interface.
+    fn internal_interface(&self) -> &Self::Interface;
+}
+
+/// A collection of traits providing access to the entire interface.
+pub trait CBaseAPI<'interface>:
+    CBaseInterfaceInfo
+    + SysAPI<'interface>
+    + VersionAPI
+    + LibraryAPI<'interface>
+    + ModuleAPI<'interface>
+{
+}
+
+impl<'interface, T> CBaseAPI<'interface> for T where
+    T: CBaseInterfaceInfo
+        + SysAPI<'interface>
+        + VersionAPI
+        + LibraryAPI<'interface>
+        + ModuleAPI<'interface>
+{
+}
+
+/// A trait that provides access to the interface.
+pub trait CBaseAccess<'interface> {
+    /// Type of the interface.
+    type Interface: CBaseAPI<'interface>;
+
+    /// Enters the critical section with the provided function.
+    ///
+    /// The calling thread will wait until it can acquire the lock.
+    ///
+    /// # Return
+    ///
+    /// Return value from the provided function.
+    fn lock<U>(&self, f: impl FnOnce(&mut Self::Interface) -> U) -> U;
+
+    /// Enters the critical section with the provided function.
+    ///
+    /// The function does nothing if the lock could not be acquired.
+    ///
+    /// # Return
+    ///
+    /// Return value from the provided function or [Option::None] if
+    /// the lock could not be acquired.
+    fn try_lock<U>(&self, f: impl FnOnce(&mut Self::Interface) -> U) -> Option<U>;
+
+    /// Enters the critical section with the provided function without locking.
+    ///
+    /// # Return
+    ///
+    /// Return value from the provided function.
+    ///
+    /// # Safety
+    ///
+    /// Most of the interface assumes that the caller has unique access to the interface.
+    /// This function can be used to bypass this restriction, if the user can guarantee
+    /// that no data-races will occur.
+    unsafe fn assume_locked<U>(&self, f: impl FnOnce(&mut Self::Interface) -> U) -> U;
+}
+
+impl SysBinding for CBaseRef<'_> {
+    #[inline]
+    unsafe fn shutdown(&mut self) -> ! {
+        SysBinding::shutdown(self._interface.into_mut().as_mut())
+    }
+
+    #[inline]
+    unsafe fn panic(&self, error: Option<NonNullConst<u8>>) -> ! {
+        SysBinding::panic(self._interface.as_ref(), error)
+    }
+
+    #[inline]
+    unsafe fn has_function(&self, id: FnId) -> Bool {
+        SysBinding::has_function(self._interface.as_ref(), id)
+    }
+
+    #[inline]
+    unsafe fn get_function(&self, id: FnId) -> Optional<fn()> {
+        SysBinding::get_function(self._interface.as_ref(), id)
+    }
+
+    #[inline]
+    unsafe fn lock(&self) {
+        SysBinding::lock(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn try_lock(&self) -> Bool {
+        SysBinding::try_lock(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn unlock(&self) {
+        SysBinding::unlock(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn get_sync_handler(&self) -> NonNullConst<SyncHandlerInterface> {
+        SysBinding::get_sync_handler(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn set_sync_handler(&mut self, handler: Option<NonNullConst<SyncHandlerInterface>>) {
+        SysBinding::set_sync_handler(self._interface.into_mut().as_mut(), handler)
+    }
+}
+
+impl VersionBinding for CBaseRef<'_> {
+    #[inline]
+    unsafe fn new_short(&self, major: i32, minor: i32, patch: i32) -> Version {
+        VersionBinding::new_short(self._interface.as_ref(), major, minor, patch)
+    }
+
+    #[inline]
+    unsafe fn new_long(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: version::ReleaseType,
+        release_number: i8,
+    ) -> Version {
+        VersionBinding::new_long(
+            self._interface.as_ref(),
+            major,
+            minor,
+            patch,
+            release_type,
+            release_number,
+        )
+    }
+
+    #[inline]
+    unsafe fn new_full(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: version::ReleaseType,
+        release_number: i8,
+        build: i64,
+    ) -> Version {
+        VersionBinding::new_full(
+            self._interface.as_ref(),
+            major,
+            minor,
+            patch,
+            release_type,
+            release_number,
+            build,
+        )
+    }
+
+    #[inline]
+    unsafe fn from_string(
+        &self,
+        buffer: NonNullConst<ConstSpan<u8>>,
+    ) -> Result<Version, version::Error> {
+        VersionBinding::from_string(self._interface.as_ref(), buffer)
+    }
+
+    #[inline]
+    unsafe fn string_length_short(&self, version: NonNullConst<Version>) -> usize {
+        VersionBinding::string_length_short(self._interface.as_ref(), version)
+    }
+
+    #[inline]
+    unsafe fn string_length_long(&self, version: NonNullConst<Version>) -> usize {
+        VersionBinding::string_length_long(self._interface.as_ref(), version)
+    }
+
+    #[inline]
+    unsafe fn string_length_full(&self, version: NonNullConst<Version>) -> usize {
+        VersionBinding::string_length_full(self._interface.as_ref(), version)
+    }
+
+    #[inline]
+    unsafe fn as_string_short(
+        &self,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, version::Error> {
+        VersionBinding::as_string_short(self._interface.as_ref(), version, buffer)
+    }
+
+    #[inline]
+    unsafe fn as_string_long(
+        &self,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, version::Error> {
+        VersionBinding::as_string_long(self._interface.as_ref(), version, buffer)
+    }
+
+    #[inline]
+    unsafe fn as_string_full(
+        &self,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, version::Error> {
+        VersionBinding::as_string_full(self._interface.as_ref(), version, buffer)
+    }
+
+    #[inline]
+    unsafe fn string_is_valid(&self, version_string: NonNullConst<ConstSpan<u8>>) -> Bool {
+        VersionBinding::string_is_valid(self._interface.as_ref(), version_string)
+    }
+
+    #[inline]
+    unsafe fn compare(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> i32 {
+        VersionBinding::compare(self._interface.as_ref(), lhs, rhs)
+    }
+
+    #[inline]
+    unsafe fn compare_weak(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> i32 {
+        VersionBinding::compare_weak(self._interface.as_ref(), lhs, rhs)
+    }
+
+    #[inline]
+    unsafe fn compare_strong(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> i32 {
+        VersionBinding::compare_strong(self._interface.as_ref(), lhs, rhs)
+    }
+
+    #[inline]
+    unsafe fn is_compatible(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> Bool {
+        VersionBinding::is_compatible(self._interface.as_ref(), lhs, rhs)
+    }
+}
+
+impl LibraryBinding for CBaseRef<'_> {
+    #[inline]
+    unsafe fn register_loader(
+        &mut self,
+        loader: NonNullConst<LibraryLoaderInterface>,
+        lib_type: NonNullConst<library::LibraryType>,
+    ) -> Result<library::LoaderHandle, library::Error> {
+        LibraryBinding::register_loader(self._interface.into_mut().as_mut(), loader, lib_type)
+    }
+
+    #[inline]
+    unsafe fn unregister_loader(
+        &mut self,
+        handle: library::LoaderHandle,
+    ) -> Result<i8, library::Error> {
+        LibraryBinding::unregister_loader(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_loader_interface(
+        &mut self,
+        handle: library::LoaderHandle,
+    ) -> Result<NonNullConst<LibraryLoaderInterface>, library::Error> {
+        LibraryBinding::get_loader_interface(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_loader_handle_from_type(
+        &self,
+        lib_type: NonNullConst<library::LibraryType>,
+    ) -> Result<library::LoaderHandle, library::Error> {
+        LibraryBinding::get_loader_handle_from_type(self._interface.as_ref(), lib_type)
+    }
+
+    #[inline]
+    unsafe fn get_loader_handle_from_library(
+        &self,
+        handle: library::LibraryHandle,
+    ) -> Result<library::LoaderHandle, library::Error> {
+        LibraryBinding::get_loader_handle_from_library(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_num_loaders(&self) -> usize {
+        LibraryBinding::get_num_loaders(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn library_exists(&self, handle: library::LibraryHandle) -> Bool {
+        LibraryBinding::library_exists(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn type_exists(&self, lib_type: NonNullConst<library::LibraryType>) -> Bool {
+        LibraryBinding::type_exists(self._interface.as_ref(), lib_type)
+    }
+
+    #[inline]
+    unsafe fn get_library_types(
+        &self,
+        buffer: NonNull<MutSpan<library::LibraryType>>,
+    ) -> Result<usize, library::Error> {
+        LibraryBinding::get_library_types(self._interface.as_ref(), buffer)
+    }
+
+    #[inline]
+    unsafe fn create_library_handle(&mut self) -> library::LibraryHandle {
+        LibraryBinding::create_library_handle(self._interface.into_mut().as_mut())
+    }
+
+    #[inline]
+    unsafe fn remove_library_handle(
+        &mut self,
+        handle: library::LibraryHandle,
+    ) -> Result<i8, library::Error> {
+        LibraryBinding::remove_library_handle(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn link_library(
+        &mut self,
+        handle: library::LibraryHandle,
+        loader: library::LoaderHandle,
+        internal: library::InternalHandle,
+    ) -> Result<i8, library::Error> {
+        LibraryBinding::link_library(
+            self._interface.into_mut().as_mut(),
+            handle,
+            loader,
+            internal,
+        )
+    }
+
+    #[inline]
+    unsafe fn get_internal_library_handle(
+        &self,
+        handle: library::LibraryHandle,
+    ) -> Result<library::InternalHandle, library::Error> {
+        LibraryBinding::get_internal_library_handle(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn load(
+        &mut self,
+        loader: library::LoaderHandle,
+        path: NonNullConst<library::OSPathChar>,
+    ) -> Result<library::LibraryHandle, library::Error> {
+        LibraryBinding::load(self._interface.into_mut().as_mut(), loader, path)
+    }
+
+    #[inline]
+    unsafe fn unload(&mut self, handle: library::LibraryHandle) -> Result<i8, library::Error> {
+        LibraryBinding::unload(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_data_symbol(
+        &self,
+        handle: library::LibraryHandle,
+        symbol: NonNullConst<u8>,
+    ) -> Result<library::Symbol<NonNullConst<c_void>>, library::Error> {
+        LibraryBinding::get_data_symbol(self._interface.as_ref(), handle, symbol)
+    }
+
+    #[inline]
+    unsafe fn get_function_symbol(
+        &self,
+        handle: library::LibraryHandle,
+        symbol: NonNullConst<u8>,
+    ) -> Result<library::Symbol<fn()>, library::Error> {
+        LibraryBinding::get_function_symbol(self._interface.as_ref(), handle, symbol)
+    }
+}
+
+impl ModuleBinding for CBaseRef<'_> {
+    #[inline]
+    unsafe fn register_loader(
+        &mut self,
+        loader: NonNullConst<ModuleLoaderInterface>,
+        mod_type: NonNullConst<module::ModuleType>,
+    ) -> Result<module::LoaderHandle, module::Error> {
+        ModuleBinding::register_loader(self._interface.into_mut().as_mut(), loader, mod_type)
+    }
+
+    #[inline]
+    unsafe fn unregister_loader(
+        &mut self,
+        loader: module::LoaderHandle,
+    ) -> Result<i8, module::Error> {
+        ModuleBinding::unregister_loader(self._interface.into_mut().as_mut(), loader)
+    }
+
+    #[inline]
+    unsafe fn get_loader_interface(
+        &mut self,
+        loader: module::LoaderHandle,
+    ) -> Result<NonNullConst<ModuleLoaderInterface>, module::Error> {
+        ModuleBinding::get_loader_interface(self._interface.into_mut().as_mut(), loader)
+    }
+
+    #[inline]
+    unsafe fn get_loader_handle_from_type(
+        &self,
+        mod_type: NonNullConst<module::ModuleType>,
+    ) -> Result<module::LoaderHandle, module::Error> {
+        ModuleBinding::get_loader_handle_from_type(self._interface.as_ref(), mod_type)
+    }
+
+    #[inline]
+    unsafe fn get_loader_handle_from_module(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<module::LoaderHandle, module::Error> {
+        ModuleBinding::get_loader_handle_from_module(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_num_modules(&self) -> usize {
+        ModuleBinding::get_num_modules(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn get_num_loaders(&self) -> usize {
+        ModuleBinding::get_num_loaders(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn get_num_exported_interfaces(&self) -> usize {
+        ModuleBinding::get_num_exported_interfaces(self._interface.as_ref())
+    }
+
+    #[inline]
+    unsafe fn module_exists(&self, handle: module::ModuleHandle) -> Bool {
+        ModuleBinding::module_exists(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn type_exists(&self, mod_type: NonNullConst<module::ModuleType>) -> Bool {
+        ModuleBinding::type_exists(self._interface.as_ref(), mod_type)
+    }
+
+    #[inline]
+    unsafe fn exported_interface_exists(
+        &self,
+        interface: NonNullConst<module::InterfaceDescriptor>,
+    ) -> Bool {
+        ModuleBinding::exported_interface_exists(self._interface.as_ref(), interface)
+    }
+
+    #[inline]
+    unsafe fn get_modules(
+        &self,
+        buffer: NonNull<MutSpan<module::ModuleInfo>>,
+    ) -> Result<usize, module::Error> {
+        ModuleBinding::get_modules(self._interface.as_ref(), buffer)
+    }
+
+    #[inline]
+    unsafe fn get_module_types(
+        &self,
+        buffer: NonNull<MutSpan<module::ModuleType>>,
+    ) -> Result<usize, module::Error> {
+        ModuleBinding::get_module_types(self._interface.as_ref(), buffer)
+    }
+
+    #[inline]
+    unsafe fn get_exported_interfaces(
+        &self,
+        buffer: NonNull<MutSpan<module::InterfaceDescriptor>>,
+    ) -> Result<usize, module::Error> {
+        ModuleBinding::get_exported_interfaces(self._interface.as_ref(), buffer)
+    }
+
+    #[inline]
+    unsafe fn get_exported_interface_handle(
+        &self,
+        interface: NonNullConst<module::InterfaceDescriptor>,
+    ) -> Result<module::ModuleHandle, module::Error> {
+        ModuleBinding::get_exported_interface_handle(self._interface.as_ref(), interface)
+    }
+
+    #[inline]
+    unsafe fn create_module_handle(&mut self) -> module::ModuleHandle {
+        ModuleBinding::create_module_handle(self._interface.into_mut().as_mut())
+    }
+
+    #[inline]
+    unsafe fn remove_module_handle(
+        &mut self,
+        handle: module::ModuleHandle,
+    ) -> Result<i8, module::Error> {
+        ModuleBinding::remove_module_handle(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn link_module(
+        &mut self,
+        handle: module::ModuleHandle,
+        loader: module::LoaderHandle,
+        internal: module::InternalHandle,
+    ) -> Result<i8, module::Error> {
+        ModuleBinding::link_module(
+            self._interface.into_mut().as_mut(),
+            handle,
+            loader,
+            internal,
+        )
+    }
+
+    #[inline]
+    unsafe fn get_internal_module_handle(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<module::InternalHandle, module::Error> {
+        ModuleBinding::get_internal_module_handle(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn add_module(
+        &mut self,
+        loader: module::LoaderHandle,
+        path: NonNullConst<library::OSPathChar>,
+    ) -> Result<module::ModuleHandle, module::Error> {
+        ModuleBinding::add_module(self._interface.into_mut().as_mut(), loader, path)
+    }
+
+    #[inline]
+    unsafe fn remove_module(&mut self, handle: module::ModuleHandle) -> Result<i8, module::Error> {
+        ModuleBinding::remove_module(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn load(&mut self, handle: module::ModuleHandle) -> Result<i8, module::Error> {
+        ModuleBinding::load(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn unload(&mut self, handle: module::ModuleHandle) -> Result<i8, module::Error> {
+        ModuleBinding::unload(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn initialize(&mut self, handle: module::ModuleHandle) -> Result<i8, module::Error> {
+        ModuleBinding::initialize(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn terminate(&mut self, handle: module::ModuleHandle) -> Result<i8, module::Error> {
+        ModuleBinding::terminate(self._interface.into_mut().as_mut(), handle)
+    }
+
+    #[inline]
+    unsafe fn add_dependency(
+        &mut self,
+        handle: module::ModuleHandle,
+        interface: NonNullConst<module::InterfaceDescriptor>,
+    ) -> Result<i8, module::Error> {
+        ModuleBinding::add_dependency(self._interface.into_mut().as_mut(), handle, interface)
+    }
+
+    #[inline]
+    unsafe fn remove_dependency(
+        &mut self,
+        handle: module::ModuleHandle,
+        interface: NonNullConst<module::InterfaceDescriptor>,
+    ) -> Result<i8, module::Error> {
+        ModuleBinding::remove_dependency(self._interface.into_mut().as_mut(), handle, interface)
+    }
+
+    #[inline]
+    unsafe fn export_interface(
+        &mut self,
+        handle: module::ModuleHandle,
+        interface: NonNullConst<module::InterfaceDescriptor>,
+    ) -> Result<i8, module::Error> {
+        ModuleBinding::export_interface(self._interface.into_mut().as_mut(), handle, interface)
+    }
+
+    #[inline]
+    unsafe fn get_load_dependencies(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<ConstSpan<module::InterfaceDescriptor>, module::Error> {
+        ModuleBinding::get_load_dependencies(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_runtime_dependencies(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<ConstSpan<module::InterfaceDescriptor>, module::Error> {
+        ModuleBinding::get_runtime_dependencies(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_exportable_interfaces(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<ConstSpan<module::InterfaceDescriptor>, module::Error> {
+        ModuleBinding::get_exportable_interfaces(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn fetch_status(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<module::ModuleStatus, module::Error> {
+        ModuleBinding::fetch_status(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_module_path(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<NonNullConst<library::OSPathChar>, module::Error> {
+        ModuleBinding::get_module_path(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_module_info(
+        &self,
+        handle: module::ModuleHandle,
+    ) -> Result<NonNullConst<module::ModuleInfo>, module::Error> {
+        ModuleBinding::get_module_info(self._interface.as_ref(), handle)
+    }
+
+    #[inline]
+    unsafe fn get_interface(
+        &self,
+        handle: module::ModuleHandle,
+        interface: NonNullConst<module::InterfaceDescriptor>,
+    ) -> Result<module::Interface, module::Error> {
+        ModuleBinding::get_interface(self._interface.as_ref(), handle, interface)
+    }
+}
+
+impl<'interface> CBaseInterfaceInfo for CBaseRef<'interface> {
+    type Interface = CBaseInterface;
+
+    #[inline]
+    fn interface_version(&self) -> Version {
+        unsafe { self._interface.as_ref().version }
+    }
+
+    #[inline]
+    fn internal_interface(&self) -> &Self::Interface {
+        unsafe { &*self._interface.as_ptr() }
+    }
+}
+
+impl<'interface> CBaseAccess<'interface> for CBase<'interface> {
+    type Interface = CBaseRef<'interface>;
+
+    #[inline]
+    fn lock<U>(&self, f: impl FnOnce(&mut Self::Interface) -> U) -> U {
+        unsafe {
+            SysBinding::lock(&*self._interface.get());
+            let result = self.assume_locked(f);
+            SysBinding::unlock(&*self._interface.get());
+            result
+        }
+    }
+
+    #[inline]
+    fn try_lock<U>(&self, f: impl FnOnce(&mut Self::Interface) -> U) -> Option<U> {
+        unsafe {
+            if SysBinding::try_lock(&*self._interface.get()) == Bool::False {
+                Option::None
+            } else {
+                let result = self.assume_locked(f);
+                SysBinding::unlock(&*self._interface.get());
+                Some(result)
+            }
+        }
+    }
+
+    #[inline]
+    unsafe fn assume_locked<U>(&self, f: impl FnOnce(&mut Self::Interface) -> U) -> U {
+        f(&mut *self._interface.get())
+    }
+}
+
+impl<'interface> CBaseInterfaceInfo for CBase<'interface> {
+    type Interface = <CBaseRef<'interface> as CBaseInterfaceInfo>::Interface;
+
+    fn interface_version(&self) -> Version {
+        unsafe { self.assume_locked(|int| CBaseInterfaceInfo::interface_version(int)) }
+    }
+
+    fn internal_interface(&self) -> &Self::Interface {
+        unsafe {
+            self.assume_locked(|int| {
+                std::mem::transmute(CBaseInterfaceInfo::internal_interface(int))
+            })
+        }
+    }
+}
+
+impl<'interface> SysAPIMin<'interface> for CBase<'interface> {
+    fn panic(&self, error: Option<impl AsRef<CStr>>) -> ! {
+        unsafe { self.assume_locked(|int| SysAPIMin::panic(int, error)) }
+    }
+
+    fn has_function<U>(&self) -> bool
+    where
+        U: FnCaster,
+    {
+        unsafe { self.assume_locked(|int| SysAPIMin::has_function::<U>(int)) }
+    }
+
+    fn get_function<U>(&self, caster: &U) -> Option<<U as FnCaster>::Type>
+    where
+        U: FnCaster,
+    {
+        unsafe { self.assume_locked(move |int| SysAPIMin::get_function(int, caster)) }
+    }
+}
+
+impl VersionBinding for CBase<'_> {
+    #[inline]
+    unsafe fn new_short(&self, major: i32, minor: i32, patch: i32) -> Version {
+        VersionBinding::new_short(&*self._interface.get(), major, minor, patch)
+    }
+
+    #[inline]
+    unsafe fn new_long(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+    ) -> Version {
+        VersionBinding::new_long(
+            &*self._interface.get(),
+            major,
+            minor,
+            patch,
+            release_type,
+            release_number,
+        )
+    }
+
+    #[inline]
+    unsafe fn new_full(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+        build: i64,
+    ) -> Version {
+        VersionBinding::new_full(
+            &*self._interface.get(),
+            major,
+            minor,
+            patch,
+            release_type,
+            release_number,
+            build,
+        )
+    }
+
+    #[inline]
+    unsafe fn from_string(&self, buffer: NonNullConst<ConstSpan<u8>>) -> Result<Version, Error> {
+        VersionBinding::from_string(&*self._interface.get(), buffer)
+    }
+
+    #[inline]
+    unsafe fn string_length_short(&self, version: NonNullConst<Version>) -> usize {
+        VersionBinding::string_length_short(&*self._interface.get(), version)
+    }
+
+    #[inline]
+    unsafe fn string_length_long(&self, version: NonNullConst<Version>) -> usize {
+        VersionBinding::string_length_long(&*self._interface.get(), version)
+    }
+
+    #[inline]
+    unsafe fn string_length_full(&self, version: NonNullConst<Version>) -> usize {
+        VersionBinding::string_length_full(&*self._interface.get(), version)
+    }
+
+    #[inline]
+    unsafe fn as_string_short(
+        &self,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, Error> {
+        VersionBinding::as_string_short(&*self._interface.get(), version, buffer)
+    }
+
+    #[inline]
+    unsafe fn as_string_long(
+        &self,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, Error> {
+        VersionBinding::as_string_long(&*self._interface.get(), version, buffer)
+    }
+
+    #[inline]
+    unsafe fn as_string_full(
+        &self,
+        version: NonNullConst<Version>,
+        buffer: NonNull<MutSpan<u8>>,
+    ) -> Result<usize, Error> {
+        VersionBinding::as_string_full(&*self._interface.get(), version, buffer)
+    }
+
+    #[inline]
+    unsafe fn string_is_valid(&self, version_string: NonNullConst<ConstSpan<u8>>) -> Bool {
+        VersionBinding::string_is_valid(&*self._interface.get(), version_string)
+    }
+
+    #[inline]
+    unsafe fn compare(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> i32 {
+        VersionBinding::compare(&*self._interface.get(), lhs, rhs)
+    }
+
+    #[inline]
+    unsafe fn compare_weak(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> i32 {
+        VersionBinding::compare_weak(&*self._interface.get(), lhs, rhs)
+    }
+
+    #[inline]
+    unsafe fn compare_strong(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> i32 {
+        VersionBinding::compare_strong(&*self._interface.get(), lhs, rhs)
+    }
+
+    #[inline]
+    unsafe fn is_compatible(&self, lhs: NonNullConst<Version>, rhs: NonNullConst<Version>) -> Bool {
+        VersionBinding::is_compatible(&*self._interface.get(), lhs, rhs)
+    }
+}

--- a/emf-core-base-rs/src/extensions.rs
+++ b/emf-core-base-rs/src/extensions.rs
@@ -1,0 +1,4 @@
+//! Extensions to the interface.
+
+#[cfg(feature = "unwind_internal")]
+pub mod unwind_internal;

--- a/emf-core-base-rs/src/extensions/unwind_internal.rs
+++ b/emf-core-base-rs/src/extensions/unwind_internal.rs
@@ -1,0 +1,437 @@
+//! The `unwind_internal` extension.
+use crate::ffi::collections::NonNullConst;
+use crate::ffi::extensions::unwind_internal;
+use crate::ffi::extensions::unwind_internal::{
+    Context, PanicFn, ShutdownFn, UnwindInternalBinding,
+};
+use crate::sys::SysAPIMin;
+use crate::CBaseAPI;
+use std::any::Any;
+use std::marker::PhantomData;
+use std::panic::UnwindSafe;
+use std::ptr::NonNull;
+
+pub use unwind_internal::UNWIND_INTERNAL_INTERFACE_NAME;
+pub use unwind_internal::UNWIND_INTERNAL_VERSION_BUILD;
+pub use unwind_internal::UNWIND_INTERNAL_VERSION_MAJOR;
+pub use unwind_internal::UNWIND_INTERNAL_VERSION_MINOR;
+pub use unwind_internal::UNWIND_INTERNAL_VERSION_PATCH;
+pub use unwind_internal::UNWIND_INTERNAL_VERSION_RELEASE_NUMBER;
+pub use unwind_internal::UNWIND_INTERNAL_VERSION_RELEASE_TYPE;
+pub use unwind_internal::UNWIND_INTERNAL_VERSION_STRING;
+
+use crate::ffi::CBaseBinding;
+use crate::CBaseInterfaceInfo;
+pub use default_context::DefaultContext;
+use std::ffi::CStr;
+
+/// Possible signals
+#[derive(Debug)]
+pub enum Signal {
+    /// A signal that requests the termination of the interface.
+    Shutdown,
+    /// A panic originating from the interface's `panic()` function.
+    Panic(Box<dyn Any + Send + 'static>),
+    /// A panic originating from an unknown source, including [panic!()].
+    Other(Box<dyn Any + Send + 'static>),
+}
+
+/// Borrowed context of the unwind_internal api.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct UnwindInternalContextRef {
+    /// Context pointer, that is passed to the shutdown and panic functions.
+    pub _context: NonNull<Context>,
+    /// Shutdown function.
+    pub _shutdown: ShutdownFn,
+    /// Panic function.
+    pub _panic: PanicFn,
+}
+
+unsafe impl Send for UnwindInternalContextRef {}
+unsafe impl Sync for UnwindInternalContextRef {}
+
+/// Interface of the `unwind_internal` extension.
+#[derive(Debug)]
+pub struct UnwindInternalInterface<'interface> {
+    _interface: NonNullConst<unwind_internal::UnwindInternalInterface>,
+    _phantom: PhantomData<&'interface unwind_internal::UnwindInternalInterface>,
+}
+
+unsafe impl Send for UnwindInternalInterface<'_> {}
+unsafe impl Sync for UnwindInternalInterface<'_> {}
+
+/// API of the `unwind_internal` interface.
+pub trait UnwindInternalAPI<'interface> {
+    /// Fetches the `unwind_internal` interface from the main interface.
+    fn from_interface(interface: &(impl SysAPIMin<'interface> + CBaseInterfaceInfo)) -> Self;
+
+    /// Retrieves a pointer to the native interface.
+    fn to_interface(&self) -> NonNullConst<unwind_internal::UnwindInternalInterface>;
+
+    /// Fetches the active context.
+    ///
+    /// # Return
+    ///
+    /// Active context.
+    fn get_context(
+        &self,
+        interface: &impl CBaseAPI<'interface>,
+    ) -> Option<UnwindInternalContextRef>;
+
+    /// Sets the new active context.
+    fn set_context(
+        &mut self,
+        interface: &mut impl CBaseAPI<'interface>,
+        context: Option<UnwindInternalContextRef>,
+    );
+}
+
+impl<'interface> UnwindInternalAPI<'interface> for UnwindInternalInterface<'interface> {
+    fn from_interface(interface: &(impl SysAPIMin<'interface> + CBaseInterfaceInfo)) -> Self {
+        use crate::fn_caster::extensions::unwind_internal as casters;
+        if let Some(unw_int_fn) =
+            SysAPIMin::get_function(interface, &casters::GetUnwindInternalInterfaceCaster {})
+        {
+            Self {
+                _interface: unsafe { unw_int_fn(interface.internal_interface().base_module()) },
+                _phantom: PhantomData,
+            }
+        } else {
+            let error = unsafe {
+                CStr::from_bytes_with_nul_unchecked(
+                    b"Could not fetch the `unwind_internal` interface!\n",
+                )
+            };
+            SysAPIMin::panic(interface, Some(error))
+        }
+    }
+
+    fn to_interface(&self) -> NonNullConst<unwind_internal::UnwindInternalInterface> {
+        self._interface
+    }
+
+    fn get_context(
+        &self,
+        interface: &impl CBaseAPI<'interface>,
+    ) -> Option<UnwindInternalContextRef> {
+        unsafe {
+            if let Some(context) = self
+                ._interface
+                .as_ref()
+                .get_context(interface.internal_interface())
+            {
+                if let Some(shutdown) = self
+                    ._interface
+                    .as_ref()
+                    .get_shutdown_fn(interface.internal_interface())
+                {
+                    if let Some(panic) = self
+                        ._interface
+                        .as_ref()
+                        .get_panic_fn(interface.internal_interface())
+                    {
+                        return Some(UnwindInternalContextRef {
+                            _context: context,
+                            _shutdown: shutdown,
+                            _panic: panic,
+                        });
+                    }
+                }
+            }
+
+            None
+        }
+    }
+
+    fn set_context(
+        &mut self,
+        interface: &mut impl CBaseAPI<'interface>,
+        context: Option<UnwindInternalContextRef>,
+    ) {
+        unsafe {
+            if let Some(context) = context {
+                self._interface
+                    .into_mut()
+                    .as_mut()
+                    .set_context(interface.internal_interface(), Some(context._context));
+                self._interface
+                    .into_mut()
+                    .as_mut()
+                    .set_shutdown_fn(interface.internal_interface(), Some(context._shutdown));
+                self._interface
+                    .into_mut()
+                    .as_mut()
+                    .set_panic_fn(interface.internal_interface(), Some(context._panic));
+            } else {
+                self._interface
+                    .into_mut()
+                    .as_mut()
+                    .set_context(interface.internal_interface(), None);
+                self._interface
+                    .into_mut()
+                    .as_mut()
+                    .set_shutdown_fn(interface.internal_interface(), None);
+                self._interface
+                    .into_mut()
+                    .as_mut()
+                    .set_panic_fn(interface.internal_interface(), None);
+            }
+        }
+    }
+}
+
+/// Interface of a unwinding context.
+pub trait UnwindInternalContextAPI<'interface> {
+    /// Sets up the unwinding for the closure `f`
+    ///
+    /// Any panic or termination signal, that occurs within `f`, is propagated.
+    ///
+    /// # Return
+    ///
+    /// Return value from `f`.
+    fn setup_unwind<T, U>(
+        &self,
+        extension: &mut impl UnwindInternalAPI<'interface>,
+        interface: &mut T,
+        f: impl FnOnce(&mut T) -> U + UnwindSafe,
+    ) -> U
+    where
+        T: CBaseAPI<'interface>;
+
+    /// Sets up the unwinding for the closure `f`
+    ///
+    /// Any panic or termination signal, that occurs within `f`, is caught and returned.
+    ///
+    /// # Return
+    ///
+    /// Return value from `f` or caught signal.
+    fn catch_unwind<T, U>(
+        &self,
+        extension: &mut impl UnwindInternalAPI<'interface>,
+        interface: &mut T,
+        f: impl FnOnce(&mut T) -> U + UnwindSafe,
+    ) -> Result<U, Signal>
+    where
+        T: CBaseAPI<'interface>;
+}
+
+pub mod default_context {
+    //! Implementation of the default context.
+    use crate::extensions::unwind_internal::{
+        Signal, UnwindInternalAPI, UnwindInternalContextAPI, UnwindInternalContextRef,
+    };
+    use crate::ffi::collections::NonNullConst;
+    use crate::ffi::extensions::unwind_internal::Context;
+    use crate::ffi::TypeWrapper;
+    use crate::CBaseAPI;
+    use backtrace::Backtrace;
+    use std::cell::UnsafeCell;
+    use std::ffi::{CStr, CString};
+    use std::panic::{AssertUnwindSafe, PanicInfo, UnwindSafe};
+    use std::ptr::NonNull;
+
+    /// Default context.
+    #[derive(Debug)]
+    pub struct DefaultContext {}
+
+    /// A shutdown signal.
+    #[derive(Debug)]
+    pub struct ShutdownSignal {}
+
+    /// A panic signal.
+    #[derive(Debug)]
+    pub struct PanicSignal {
+        /// Error message of the panic.
+        pub error: UnsafeCell<Option<CString>>,
+    }
+
+    extern "C-unwind" fn shutdown_fn(_context: Option<NonNull<Context>>) -> ! {
+        std::panic::panic_any(ShutdownSignal {})
+    }
+
+    extern "C-unwind" fn panic_fn(
+        _context: Option<NonNull<Context>>,
+        err: Option<NonNullConst<u8>>,
+    ) -> ! {
+        let error = {
+            if let Some(err) = err {
+                let err_str = unsafe { CStr::from_ptr(err.cast().as_ptr()) };
+                PanicSignal {
+                    error: UnsafeCell::new(Some(err_str.to_owned())),
+                }
+            } else {
+                PanicSignal {
+                    error: UnsafeCell::new(None),
+                }
+            }
+        };
+        std::panic::panic_any(error)
+    }
+
+    fn panic_hook(info: &PanicInfo<'_>) {
+        let backtrace = Backtrace::new();
+        if let Some(payload) = info.payload().downcast_ref::<PanicSignal>() {
+            let error = unsafe { &mut *payload.error.get() };
+            if let Some(error) = error {
+                let mut error_vec = Vec::from(error.as_bytes());
+                error_vec.extend_from_slice("\n\nBacktrace:\n".as_bytes());
+                error_vec.extend_from_slice(format!("{:?}", backtrace).as_bytes());
+
+                *error = CString::new(error_vec).unwrap();
+            } else {
+                let trace = CString::new(format!("Backtrace:\n{:?}", backtrace)).unwrap();
+                *error = Some(trace);
+            }
+        }
+    }
+
+    impl Default for DefaultContext {
+        fn default() -> Self {
+            DefaultContext {}
+        }
+    }
+
+    impl<'interface> UnwindInternalContextAPI<'interface> for DefaultContext {
+        fn setup_unwind<T, U>(
+            &self,
+            extension: &mut impl UnwindInternalAPI<'interface>,
+            interface: &mut T,
+            f: impl FnOnce(&mut T) -> U + UnwindSafe,
+        ) -> U
+        where
+            T: CBaseAPI<'interface>,
+        {
+            let result = self.catch_unwind(extension, interface, f);
+
+            match result {
+                Ok(v) => v,
+                Err(sig) => match sig {
+                    Signal::Shutdown => interface.shutdown(),
+                    Signal::Panic(err) => {
+                        let error = err.downcast_ref::<PanicSignal>().unwrap();
+                        interface.panic(unsafe { (&*error.error.get()).as_ref() })
+                    }
+                    Signal::Other(err) => {
+                        if let Some(error) = err.downcast_ref::<&str>() {
+                            if let Ok(error) = CString::new(*error) {
+                                interface.panic(Some(error))
+                            }
+                        }
+                        let error = unsafe {
+                            CStr::from_bytes_with_nul_unchecked(b"Unknown error occurred!\0")
+                        };
+                        interface.panic(Some(error))
+                    }
+                },
+            }
+        }
+
+        fn catch_unwind<T, U>(
+            &self,
+            extension: &mut impl UnwindInternalAPI<'interface>,
+            interface: &mut T,
+            f: impl FnOnce(&mut T) -> U + UnwindSafe,
+        ) -> Result<U, Signal>
+        where
+            T: CBaseAPI<'interface>,
+        {
+            let saved_context = extension.get_context(interface);
+            let saved_panic_hook = std::panic::take_hook();
+
+            let context = UnwindInternalContextRef {
+                _context: NonNull::dangling(),
+                _shutdown: TypeWrapper(shutdown_fn),
+                _panic: TypeWrapper(panic_fn),
+            };
+
+            extension.set_context(interface, Some(context));
+            std::panic::set_hook(Box::new(panic_hook));
+
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| f(interface)));
+
+            std::panic::set_hook(saved_panic_hook);
+            extension.set_context(interface, saved_context);
+
+            result.map_err(|e| {
+                if e.is::<ShutdownSignal>() {
+                    Signal::Shutdown
+                } else if e.is::<PanicSignal>() {
+                    Signal::Panic(e)
+                } else {
+                    Signal::Other(e)
+                }
+            })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::extensions::unwind_internal::default_context::{
+            panic_fn, panic_hook, shutdown_fn, PanicSignal, ShutdownSignal,
+        };
+        use crate::ffi::collections::NonNullConst;
+
+        #[test]
+        fn test_rust_panic() {
+            let saved_panic_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(panic_hook));
+            let result = std::panic::catch_unwind(|| panic!("My panic message!"));
+            std::panic::set_hook(saved_panic_hook);
+
+            assert_eq!(result.is_err(), true);
+            let error = result.unwrap_err();
+            assert_eq!(error.is::<ShutdownSignal>(), false);
+            assert_eq!(error.is::<PanicSignal>(), false);
+        }
+
+        #[test]
+        fn test_ext_shutdown() {
+            let saved_panic_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(panic_hook));
+            let result = std::panic::catch_unwind(|| shutdown_fn(None));
+            std::panic::set_hook(saved_panic_hook);
+
+            assert_eq!(result.is_err(), true);
+            let error = result.unwrap_err();
+            assert_eq!(error.is::<ShutdownSignal>(), true);
+        }
+
+        #[test]
+        fn test_ext_panic() {
+            let saved_panic_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(panic_hook));
+            let result = std::panic::catch_unwind(|| {
+                panic_fn(None, Some(NonNullConst::from(b"My panic message!\0")))
+            });
+            std::panic::set_hook(saved_panic_hook);
+
+            assert_eq!(result.is_err(), true);
+            let mut error = result.unwrap_err();
+            assert_eq!(error.is::<PanicSignal>(), true);
+            let signal = error.downcast_mut::<PanicSignal>().unwrap();
+            let error = signal.error.get_mut();
+            assert_eq!(error.is_some(), true);
+            let error = error.as_ref().unwrap();
+            let error = error.to_str().unwrap();
+            print!("{}", error);
+        }
+
+        #[test]
+        fn test_ext_panic_empty() {
+            let saved_panic_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(panic_hook));
+            let result = std::panic::catch_unwind(|| panic_fn(None, None));
+            std::panic::set_hook(saved_panic_hook);
+
+            assert_eq!(result.is_err(), true);
+            let mut error = result.unwrap_err();
+            assert_eq!(error.is::<PanicSignal>(), true);
+            let signal = error.downcast_mut::<PanicSignal>().unwrap();
+            let error = signal.error.get_mut();
+            assert_eq!(error.is_some(), true);
+            let error = error.as_ref().unwrap();
+            let error = error.to_str().unwrap();
+            print!("{}", error);
+        }
+    }
+}

--- a/emf-core-base-rs/src/fn_caster.rs
+++ b/emf-core-base-rs/src/fn_caster.rs
@@ -1,0 +1,36 @@
+//! Utilities for casting interface functions.
+use crate::ffi::{CBaseFn, FnId};
+
+/// Interface of a function caster.
+pub trait FnCaster {
+    /// Type of the function.
+    type Type;
+
+    /// Id of the function
+    const ID: FnId;
+
+    /// Cast unsafe the function to a safer type.
+    fn cast(&self, func: CBaseFn) -> Self::Type;
+}
+
+macro_rules! transmute_caster {
+    ($caster:ty, $target_fn:ty, $target_id:expr) => {
+        impl FnCaster for $caster {
+            type Type = $target_fn;
+            const ID: FnId = $target_id;
+
+            #[inline]
+            fn cast(&self, func: CBaseFn) -> Self::Type {
+                unsafe { std::mem::transmute(func) }
+            }
+        }
+    };
+}
+
+pub mod library;
+pub mod module;
+pub mod sys;
+pub mod version;
+
+#[cfg(feature = "extensions")]
+pub mod extensions;

--- a/emf-core-base-rs/src/fn_caster/extensions.rs
+++ b/emf-core-base-rs/src/fn_caster/extensions.rs
@@ -1,0 +1,4 @@
+//! Casters for the interface extensions.
+
+#[cfg(feature = "unwind_internal")]
+pub mod unwind_internal;

--- a/emf-core-base-rs/src/fn_caster/extensions/unwind_internal.rs
+++ b/emf-core-base-rs/src/fn_caster/extensions/unwind_internal.rs
@@ -1,0 +1,14 @@
+//! Casters for the `unwind_internal` extension.
+use crate::ffi::extensions::unwind_internal;
+use crate::ffi::{CBaseFn, FnId};
+use crate::fn_caster::FnCaster;
+
+/// Caster for [FnId::ExtGetUnwindInternalInterface]
+#[derive(Debug)]
+pub struct GetUnwindInternalInterfaceCaster {}
+
+transmute_caster!(
+    GetUnwindInternalInterfaceCaster,
+    unwind_internal::GetUnwindInternalInterfaceFn,
+    FnId::ExtGetUnwindInternalInterface
+);

--- a/emf-core-base-rs/src/fn_caster/library.rs
+++ b/emf-core-base-rs/src/fn_caster/library.rs
@@ -1,0 +1,162 @@
+//! Casters for the library api.
+use crate::ffi::library::api;
+use crate::ffi::{CBaseFn, FnId};
+use crate::fn_caster::FnCaster;
+
+/// Caster for [FnId::LibraryRegisterLoader]
+#[derive(Debug)]
+pub struct RegisterLoaderCaster {}
+
+/// Caster for [FnId::LibraryUnregisterLoader]
+#[derive(Debug)]
+pub struct UnregisterLoaderCaster {}
+
+/// Caster for [FnId::LibraryGetLoaderInterface]
+#[derive(Debug)]
+pub struct GetLoaderInterfaceCaster {}
+
+/// Caster for [FnId::LibraryGetLoaderHandleFromType]
+#[derive(Debug)]
+pub struct GetLoaderHandleFromTypeCaster {}
+
+/// Caster for [FnId::LibraryGetLoaderHandleFromLibrary]
+#[derive(Debug)]
+pub struct GetLoaderHandleFromLibraryCaster {}
+
+/// Caster for [FnId::LibraryGetNumLoaders]
+#[derive(Debug)]
+pub struct GetNumLoadersCaster {}
+
+/// Caster for [FnId::LibraryLibraryExists]
+#[derive(Debug)]
+pub struct LibraryExistsCaster {}
+
+/// Caster for [FnId::LibraryTypeExists]
+#[derive(Debug)]
+pub struct TypeExistsCaster {}
+
+/// Caster for [FnId::LibraryGetLibraryTypes]
+#[derive(Debug)]
+pub struct GetLibraryTypesCaster {}
+
+/// Caster for [FnId::LibraryCreateLibraryHandle]
+#[derive(Debug)]
+pub struct CreateLibraryHandleCaster {}
+
+/// Caster for [FnId::LibraryRemoveLibraryHandle]
+#[derive(Debug)]
+pub struct RemoveLibraryHandleCaster {}
+
+/// Caster for [FnId::LibraryLinkLibrary]
+#[derive(Debug)]
+pub struct LinkLibraryCaster {}
+
+/// Caster for [FnId::LibraryGetInternalLibraryHandle]
+#[derive(Debug)]
+pub struct GetInternalLibraryHandleCaster {}
+
+/// Caster for [FnId::LibraryLoad]
+#[derive(Debug)]
+pub struct LoadCaster {}
+
+/// Caster for [FnId::LibraryUnload]
+#[derive(Debug)]
+pub struct UnloadCaster {}
+
+/// Caster for [FnId::LibraryGetDataSymbol]
+#[derive(Debug)]
+pub struct GetDataSymbolCaster {}
+
+/// Caster for [FnId::LibraryGetFunctionSymbol]
+#[derive(Debug)]
+pub struct GetFunctionSymbolCaster {}
+
+transmute_caster!(
+    RegisterLoaderCaster,
+    api::RegisterLoaderFn,
+    FnId::LibraryRegisterLoader
+);
+
+transmute_caster!(
+    UnregisterLoaderCaster,
+    api::UnregisterLoaderFn,
+    FnId::LibraryUnregisterLoader
+);
+
+transmute_caster!(
+    GetLoaderInterfaceCaster,
+    api::GetLoaderInterfaceFn,
+    FnId::LibraryGetLoaderInterface
+);
+
+transmute_caster!(
+    GetLoaderHandleFromTypeCaster,
+    api::GetLoaderHandleFromTypeFn,
+    FnId::LibraryGetLoaderHandleFromType
+);
+
+transmute_caster!(
+    GetLoaderHandleFromLibraryCaster,
+    api::GetLoaderHandleFromLibraryFn,
+    FnId::LibraryGetLoaderHandleFromLibrary
+);
+
+transmute_caster!(
+    GetNumLoadersCaster,
+    api::GetNumLoadersFn,
+    FnId::LibraryGetNumLoaders
+);
+
+transmute_caster!(
+    LibraryExistsCaster,
+    api::LibraryExistsFn,
+    FnId::LibraryLibraryExists
+);
+
+transmute_caster!(TypeExistsCaster, api::TypeExistsFn, FnId::LibraryTypeExists);
+
+transmute_caster!(
+    GetLibraryTypesCaster,
+    api::GetLibraryTypesFn,
+    FnId::LibraryGetLibraryTypes
+);
+
+transmute_caster!(
+    CreateLibraryHandleCaster,
+    api::CreateLibraryHandleFn,
+    FnId::LibraryCreateLibraryHandle
+);
+
+transmute_caster!(
+    RemoveLibraryHandleCaster,
+    api::RemoveLibraryHandleFn,
+    FnId::LibraryRemoveLibraryHandle
+);
+
+transmute_caster!(
+    LinkLibraryCaster,
+    api::LinkLibraryFn,
+    FnId::LibraryLinkLibrary
+);
+
+transmute_caster!(
+    GetInternalLibraryHandleCaster,
+    api::GetInternalLibraryHandleFn,
+    FnId::LibraryGetInternalLibraryHandle
+);
+
+transmute_caster!(LoadCaster, api::LoadFn, FnId::LibraryLoad);
+
+transmute_caster!(UnloadCaster, api::UnloadFn, FnId::LibraryUnload);
+
+transmute_caster!(
+    GetDataSymbolCaster,
+    api::GetDataSymbolFn,
+    FnId::LibraryGetDataSymbol
+);
+
+transmute_caster!(
+    GetFunctionSymbolCaster,
+    api::GetFunctionSymbolFn,
+    FnId::LibraryGetFunctionSymbol
+);

--- a/emf-core-base-rs/src/fn_caster/module.rs
+++ b/emf-core-base-rs/src/fn_caster/module.rs
@@ -1,0 +1,322 @@
+//! Casters for the module api.
+use crate::ffi::module::api;
+use crate::ffi::{CBaseFn, FnId};
+use crate::fn_caster::FnCaster;
+
+/// Caster for [FnId::ModuleRegisterLoader]
+#[derive(Debug)]
+pub struct RegisterLoaderCaster {}
+
+/// Caster for [FnId::ModuleUnregisterLoader]
+#[derive(Debug)]
+pub struct UnregisterLoaderCaster {}
+
+/// Caster for [FnId::ModuleGetLoaderInterface]
+#[derive(Debug)]
+pub struct GetLoaderInterfaceCaster {}
+
+/// Caster for [FnId::ModuleGetLoaderHandleFromType]
+#[derive(Debug)]
+pub struct GetLoaderHandleFromTypeCaster {}
+
+/// Caster for [FnId::ModuleGetLoaderHandleFromModule]
+#[derive(Debug)]
+pub struct GetLoaderHandleFromModuleCaster {}
+
+/// Caster for [FnId::ModuleGetNumModules]
+#[derive(Debug)]
+pub struct GetNumModulesCaster {}
+
+/// Caster for [FnId::ModuleGetNumLoaders]
+#[derive(Debug)]
+pub struct GetNumLoadersCaster {}
+
+/// Caster for [FnId::ModuleGetNumExportedInterfaces]
+#[derive(Debug)]
+pub struct GetNumExportedInterfacesCaster {}
+
+/// Caster for [FnId::ModuleModuleExists]
+#[derive(Debug)]
+pub struct ModuleExistsCaster {}
+
+/// Caster for [FnId::ModuleTypeExists]
+#[derive(Debug)]
+pub struct TypeExistsCaster {}
+
+/// Caster for [FnId::ModuleExportedInterfaceExists]
+#[derive(Debug)]
+pub struct ExportedInterfaceExistsCaster {}
+
+/// Caster for [FnId::ModuleGetModules]
+#[derive(Debug)]
+pub struct GetModulesCaster {}
+
+/// Caster for [FnId::ModuleGetModuleTypes]
+#[derive(Debug)]
+pub struct GetModuleTypesCaster {}
+
+/// Caster for [FnId::ModuleGetExportedInterfaces]
+#[derive(Debug)]
+pub struct GetExportedInterfacesCaster {}
+
+/// Caster for [FnId::ModuleGetExportedInterfaceHandle]
+#[derive(Debug)]
+pub struct GetExportedInterfaceHandleCaster {}
+
+/// Caster for [FnId::ModuleCreateModuleHandle]
+#[derive(Debug)]
+pub struct CreateModuleHandleCaster {}
+
+/// Caster for [FnId::ModuleRemoveModuleHandle]
+#[derive(Debug)]
+pub struct RemoveModuleHandleCaster {}
+
+/// Caster for [FnId::ModuleLinkModule]
+#[derive(Debug)]
+pub struct LinkModuleCaster {}
+
+/// Caster for [FnId::ModuleGetInternalModuleHandle]
+#[derive(Debug)]
+pub struct GetInternalModuleHandleCaster {}
+
+/// Caster for [FnId::ModuleAddModule]
+#[derive(Debug)]
+pub struct AddModuleCaster {}
+
+/// Caster for [FnId::ModuleRemoveModule]
+#[derive(Debug)]
+pub struct RemoveModuleCaster {}
+
+/// Caster for [FnId::ModuleLoad]
+#[derive(Debug)]
+pub struct LoadCaster {}
+
+/// Caster for [FnId::ModuleUnload]
+#[derive(Debug)]
+pub struct UnloadCaster {}
+
+/// Caster for [FnId::ModuleInitialize]
+#[derive(Debug)]
+pub struct InitializeCaster {}
+
+/// Caster for [FnId::ModuleTerminate]
+#[derive(Debug)]
+pub struct TerminateCaster {}
+
+/// Caster for [FnId::ModuleAddDependency]
+#[derive(Debug)]
+pub struct AddDependencyCaster {}
+
+/// Caster for [FnId::ModuleRemoveDependency]
+#[derive(Debug)]
+pub struct RemoveDependencyCaster {}
+
+/// Caster for [FnId::ModuleExportInterface]
+#[derive(Debug)]
+pub struct ExportInterfaceCaster {}
+
+/// Caster for [FnId::ModuleGetLoadDependencies]
+#[derive(Debug)]
+pub struct GetLoadDependenciesCaster {}
+
+/// Caster for [FnId::ModuleGetRuntimeDependencies]
+#[derive(Debug)]
+pub struct GetRuntimeDependenciesCaster {}
+
+/// Caster for [FnId::ModuleGetExportableInterfaces]
+#[derive(Debug)]
+pub struct GetExportableInterfacesCaster {}
+
+/// Caster for [FnId::ModuleFetchStatus]
+#[derive(Debug)]
+pub struct FetchStatusCaster {}
+
+/// Caster for [FnId::ModuleGetModulePath]
+#[derive(Debug)]
+pub struct GetModulePathCaster {}
+
+/// Caster for [FnId::ModuleGetModuleInfo]
+#[derive(Debug)]
+pub struct GetModuleInfoCaster {}
+
+/// Caster for [FnId::ModuleGetInterface]
+#[derive(Debug)]
+pub struct GetInterfaceCaster {}
+
+transmute_caster!(
+    RegisterLoaderCaster,
+    api::RegisterLoaderFn,
+    FnId::ModuleRegisterLoader
+);
+
+transmute_caster!(
+    UnregisterLoaderCaster,
+    api::UnregisterLoaderFn,
+    FnId::ModuleUnregisterLoader
+);
+
+transmute_caster!(
+    GetLoaderInterfaceCaster,
+    api::GetLoaderInterfaceFn,
+    FnId::ModuleGetLoaderInterface
+);
+
+transmute_caster!(
+    GetLoaderHandleFromTypeCaster,
+    api::GetLoaderHandleFromTypeFn,
+    FnId::ModuleGetLoaderHandleFromType
+);
+
+transmute_caster!(
+    GetLoaderHandleFromModuleCaster,
+    api::GetLoaderHandleFromModuleFn,
+    FnId::ModuleGetLoaderHandleFromModule
+);
+
+transmute_caster!(
+    GetNumModulesCaster,
+    api::GetNumModulesFn,
+    FnId::ModuleGetNumModules
+);
+
+transmute_caster!(
+    GetNumLoadersCaster,
+    api::GetNumLoadersFn,
+    FnId::ModuleGetNumLoaders
+);
+
+transmute_caster!(
+    GetNumExportedInterfacesCaster,
+    api::GetNumExportedInterfacesFn,
+    FnId::ModuleGetNumExportedInterfaces
+);
+
+transmute_caster!(
+    ModuleExistsCaster,
+    api::ModuleExistsFn,
+    FnId::ModuleModuleExists
+);
+
+transmute_caster!(TypeExistsCaster, api::TypeExistsFn, FnId::ModuleTypeExists);
+
+transmute_caster!(
+    ExportedInterfaceExistsCaster,
+    api::ExportedInterfaceExistsFn,
+    FnId::ModuleExportedInterfaceExists
+);
+
+transmute_caster!(GetModulesCaster, api::GetModulesFn, FnId::ModuleGetModules);
+
+transmute_caster!(
+    GetModuleTypesCaster,
+    api::GetModuleTypesFn,
+    FnId::ModuleGetModuleTypes
+);
+
+transmute_caster!(
+    GetExportedInterfacesCaster,
+    api::GetExportedInterfacesFn,
+    FnId::ModuleGetExportedInterfaces
+);
+
+transmute_caster!(
+    GetExportedInterfaceHandleCaster,
+    api::GetExportedInterfaceHandleFn,
+    FnId::ModuleGetExportedInterfaceHandle
+);
+
+transmute_caster!(
+    CreateModuleHandleCaster,
+    api::CreateModuleHandleFn,
+    FnId::ModuleCreateModuleHandle
+);
+
+transmute_caster!(
+    RemoveModuleHandleCaster,
+    api::RemoveModuleHandleFn,
+    FnId::ModuleRemoveModuleHandle
+);
+
+transmute_caster!(LinkModuleCaster, api::LinkModuleFn, FnId::ModuleLinkModule);
+
+transmute_caster!(
+    GetInternalModuleHandleCaster,
+    api::GetInternalModuleHandleFn,
+    FnId::ModuleGetInternalModuleHandle
+);
+
+transmute_caster!(AddModuleCaster, api::AddModuleFn, FnId::ModuleAddModule);
+
+transmute_caster!(
+    RemoveModuleCaster,
+    api::RemoveModuleFn,
+    FnId::ModuleRemoveModule
+);
+
+transmute_caster!(LoadCaster, api::LoadFn, FnId::ModuleLoad);
+
+transmute_caster!(UnloadCaster, api::UnloadFn, FnId::ModuleUnload);
+
+transmute_caster!(InitializeCaster, api::InitializeFn, FnId::ModuleInitialize);
+
+transmute_caster!(TerminateCaster, api::TerminateFn, FnId::ModuleTerminate);
+
+transmute_caster!(
+    AddDependencyCaster,
+    api::AddDependencyFn,
+    FnId::ModuleAddDependency
+);
+
+transmute_caster!(
+    RemoveDependencyCaster,
+    api::RemoveDependencyFn,
+    FnId::ModuleRemoveDependency
+);
+
+transmute_caster!(
+    ExportInterfaceCaster,
+    api::ExportInterfaceFn,
+    FnId::ModuleExportInterface
+);
+
+transmute_caster!(
+    GetLoadDependenciesCaster,
+    api::GetLoadDependenciesFn,
+    FnId::ModuleGetLoadDependencies
+);
+
+transmute_caster!(
+    GetRuntimeDependenciesCaster,
+    api::GetRuntimeDependenciesFn,
+    FnId::ModuleGetRuntimeDependencies
+);
+
+transmute_caster!(
+    GetExportableInterfacesCaster,
+    api::GetExportableInterfacesFn,
+    FnId::ModuleGetExportableInterfaces
+);
+
+transmute_caster!(
+    FetchStatusCaster,
+    api::FetchStatusFn,
+    FnId::ModuleFetchStatus
+);
+
+transmute_caster!(
+    GetModulePathCaster,
+    api::GetModulePathFn,
+    FnId::ModuleGetModulePath
+);
+
+transmute_caster!(
+    GetModuleInfoCaster,
+    api::GetModuleInfoFn,
+    FnId::ModuleGetModuleInfo
+);
+
+transmute_caster!(
+    GetInterfaceCaster,
+    api::GetInterfaceFn,
+    FnId::ModuleGetInterface
+);

--- a/emf-core-base-rs/src/fn_caster/sys.rs
+++ b/emf-core-base-rs/src/fn_caster/sys.rs
@@ -1,0 +1,66 @@
+//! Casters for the sys api.
+use crate::ffi::sys::api;
+use crate::ffi::{CBaseFn, FnId};
+use crate::fn_caster::FnCaster;
+
+/// Caster for [FnId::SysShutdown]
+#[derive(Debug)]
+pub struct ShutdownCaster {}
+
+/// Caster for [FnId::SysPanic]
+#[derive(Debug)]
+pub struct PanicCaster {}
+
+/// Caster for [FnId::SysHasFunction]
+#[derive(Debug)]
+pub struct HasFunctionCaster {}
+
+/// Caster for [FnId::SysGetFunction]
+#[derive(Debug)]
+pub struct GetFunctionCaster {}
+
+/// Caster for [FnId::SysLock]
+#[derive(Debug)]
+pub struct LockCaster {}
+
+/// Caster for [FnId::SysTryLock]
+#[derive(Debug)]
+pub struct TryLockCaster {}
+
+/// Caster for [FnId::SysUnlock]
+#[derive(Debug)]
+pub struct UnlockCaster {}
+
+/// Caster for [FnId::SysGetSyncHandler]
+#[derive(Debug)]
+pub struct GetSyncHandlerCaster {}
+
+/// Caster for [FnId::SysSetSyncHandler]
+#[derive(Debug)]
+pub struct SetSyncHandlerCaster {}
+
+transmute_caster!(ShutdownCaster, api::ShutdownFn, FnId::SysShutdown);
+
+transmute_caster!(PanicCaster, api::PanicFn, FnId::SysPanic);
+
+transmute_caster!(HasFunctionCaster, api::HasFunctionFn, FnId::SysHasFunction);
+
+transmute_caster!(GetFunctionCaster, api::GetFunctionFn, FnId::SysGetFunction);
+
+transmute_caster!(LockCaster, api::LockFn, FnId::SysLock);
+
+transmute_caster!(TryLockCaster, api::TryLockFn, FnId::SysTryLock);
+
+transmute_caster!(UnlockCaster, api::UnlockFn, FnId::SysUnlock);
+
+transmute_caster!(
+    GetSyncHandlerCaster,
+    api::GetSyncHandlerFn,
+    FnId::SysGetSyncHandler
+);
+
+transmute_caster!(
+    SetSyncHandlerCaster,
+    api::SetSyncHandlerFn,
+    FnId::SysSetSyncHandler
+);

--- a/emf-core-base-rs/src/fn_caster/version.rs
+++ b/emf-core-base-rs/src/fn_caster/version.rs
@@ -1,0 +1,134 @@
+//! Casters for the version api.
+use crate::ffi::version::api;
+use crate::ffi::{CBaseFn, FnId};
+use crate::fn_caster::FnCaster;
+
+/// Caster for [FnId::VersionNewShort]
+#[derive(Debug)]
+pub struct NewShortCaster {}
+
+/// Caster for [FnId::VersionNewLong]
+#[derive(Debug)]
+pub struct NewLongCaster {}
+
+/// Caster for [FnId::VersionNewFull]
+#[derive(Debug)]
+pub struct NewFullCaster {}
+
+/// Caster for [FnId::VersionFromString]
+#[derive(Debug)]
+pub struct FromStringCaster {}
+
+/// Caster for [FnId::VersionStringLengthShort]
+#[derive(Debug)]
+pub struct StringLengthShortCaster {}
+
+/// Caster for [FnId::VersionStringLengthLong]
+#[derive(Debug)]
+pub struct StringLengthLongCaster {}
+
+/// Caster for [FnId::VersionStringLengthFull]
+#[derive(Debug)]
+pub struct StringLengthFullCaster {}
+
+/// Caster for [FnId::VersionAsStringShort]
+#[derive(Debug)]
+pub struct AsStringShortCaster {}
+
+/// Caster for [FnId::VersionAsStringLong]
+#[derive(Debug)]
+pub struct AsStringLongCaster {}
+
+/// Caster for [FnId::VersionAsStringFull]
+#[derive(Debug)]
+pub struct AsStringFullCaster {}
+
+/// Caster for [FnId::VersionStringIsValid]
+#[derive(Debug)]
+pub struct StringIsValidCaster {}
+
+/// Caster for [FnId::VersionCompare]
+#[derive(Debug)]
+pub struct CompareCaster {}
+
+/// Caster for [FnId::VersionCompareWeak]
+#[derive(Debug)]
+pub struct CompareWeakCaster {}
+
+/// Caster for [FnId::VersionCompareStrong]
+#[derive(Debug)]
+pub struct CompareStrongCaster {}
+
+/// Caster for [FnId::VersionIsCompatible]
+#[derive(Debug)]
+pub struct IsCompatibleCaster {}
+
+transmute_caster!(NewShortCaster, api::NewShortFn, FnId::VersionNewShort);
+
+transmute_caster!(NewLongCaster, api::NewLongFn, FnId::VersionNewLong);
+
+transmute_caster!(NewFullCaster, api::NewFullFn, FnId::VersionNewFull);
+
+transmute_caster!(FromStringCaster, api::FromStringFn, FnId::VersionFromString);
+
+transmute_caster!(
+    StringLengthShortCaster,
+    api::StringLengthShortFn,
+    FnId::VersionStringLengthShort
+);
+
+transmute_caster!(
+    StringLengthLongCaster,
+    api::StringLengthLongFn,
+    FnId::VersionStringLengthLong
+);
+
+transmute_caster!(
+    StringLengthFullCaster,
+    api::StringLengthFullFn,
+    FnId::VersionStringLengthFull
+);
+
+transmute_caster!(
+    AsStringShortCaster,
+    api::AsStringShortFn,
+    FnId::VersionAsStringShort
+);
+
+transmute_caster!(
+    AsStringLongCaster,
+    api::AsStringLongFn,
+    FnId::VersionAsStringLong
+);
+
+transmute_caster!(
+    AsStringFullCaster,
+    api::AsStringFullFn,
+    FnId::VersionAsStringFull
+);
+
+transmute_caster!(
+    StringIsValidCaster,
+    api::StringIsValidFn,
+    FnId::VersionStringIsValid
+);
+
+transmute_caster!(CompareCaster, api::CompareFn, FnId::VersionCompare);
+
+transmute_caster!(
+    CompareWeakCaster,
+    api::CompareWeakFn,
+    FnId::VersionCompareWeak
+);
+
+transmute_caster!(
+    CompareStrongCaster,
+    api::CompareStrongFn,
+    FnId::VersionCompareStrong
+);
+
+transmute_caster!(
+    IsCompatibleCaster,
+    api::IsCompatibleFn,
+    FnId::VersionIsCompatible
+);

--- a/emf-core-base-rs/src/global.rs
+++ b/emf-core-base-rs/src/global.rs
@@ -1,0 +1,160 @@
+//! Global api that can be used instead of the local api.
+//!
+//! The global api is the preferred way of interfacing with the interface.
+use crate::ffi::{
+    collections::NonNullConst,
+    sys::api::{GetFunctionFn as GetFunctionFnFFI, SysBinding},
+    Bool, CBase as CBaseFFI,
+};
+use crate::init::CBaseAPILoader;
+use crate::{CBase, CBaseInterfaceInfo, CBaseRef};
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+
+pub mod library;
+pub mod module;
+pub mod sys;
+pub mod version;
+
+#[cfg(feature = "extensions")]
+pub mod extensions;
+
+static mut INTERFACE: MaybeUninit<CBaseRef<'static>> = MaybeUninit::uninit();
+
+/// Type indicating that dropping unlocks the interface.
+#[derive(Debug)]
+pub struct Unlock {}
+
+/// Type indicating that dropping does not unlock the interface.
+#[derive(Debug)]
+pub struct ForgetUnlock {}
+
+impl Drop for Unlock {
+    fn drop(&mut self) {
+        unsafe { SysBinding::unlock(get_interface()) }
+    }
+}
+
+/// A token indicating a locked interface.
+#[derive(Debug)]
+pub struct LockToken<T> {
+    _phantom: T,
+}
+
+impl LockToken<Unlock> {
+    /// Takes ownership of the token and exchanges it with
+    /// a token which does not unlock the interface.
+    ///
+    /// # Safety
+    ///
+    /// Improper usage can leave the interface in a locked state.
+    pub unsafe fn relinquish_locking(self) -> LockToken<ForgetUnlock> {
+        std::mem::forget(self);
+        LockToken {
+            _phantom: ForgetUnlock {},
+        }
+    }
+}
+
+impl LockToken<ForgetUnlock> {
+    /// Takes ownership of the token and exchanges it with
+    /// a token which unlocks the interface.
+    ///
+    /// # Safety
+    ///
+    /// Improper usage can unlock the interface multiple times.
+    pub unsafe fn take_ownership(self) -> LockToken<Unlock> {
+        std::mem::forget(self);
+        LockToken {
+            _phantom: Unlock {},
+        }
+    }
+}
+
+impl<T> LockToken<T> {
+    /// Constructs a new token by locking the interface.
+    ///
+    /// The calling thread is stalled until the lock can be acquired.
+    /// Only one thread can hold the lock at a time.
+    ///
+    /// # Return
+    ///
+    /// A token.
+    #[inline]
+    #[must_use]
+    pub fn lock() -> LockToken<Unlock> {
+        unsafe {
+            SysBinding::lock(get_interface());
+            LockToken {
+                _phantom: Unlock {},
+            }
+        }
+    }
+
+    /// Tries to lock the interface.
+    ///
+    /// The function fails if another thread already holds the lock.
+    ///
+    /// # Return
+    ///
+    /// [LockToken] on success and [None] otherwise.
+    #[inline]
+    #[must_use]
+    pub fn try_lock() -> Option<LockToken<Unlock>> {
+        unsafe {
+            match SysBinding::try_lock(get_interface()) {
+                Bool::False => None,
+                Bool::True => Some(LockToken {
+                    _phantom: Unlock {},
+                }),
+            }
+        }
+    }
+
+    /// Constructs a new token without locking.
+    ///
+    /// # Return
+    ///
+    /// A token.
+    ///
+    /// # Safety
+    ///
+    /// Most of the interface assumes that the caller has unique access to the interface.
+    /// This function can be used to bypass this restriction, if the user can guarantee
+    /// that no data-races will occur.
+    #[inline]
+    pub unsafe fn assume_locked() -> LockToken<ForgetUnlock> {
+        LockToken {
+            _phantom: ForgetUnlock {},
+        }
+    }
+}
+
+/// Initializes the interface.
+#[inline]
+pub fn initialize(base_module: Option<NonNull<CBaseFFI>>, get_function_fn: GetFunctionFnFFI) {
+    unsafe {
+        INTERFACE = MaybeUninit::new(CBaseRef::new(NonNullConst::from(
+            CBase::fetch_interface(base_module, get_function_fn).internal_interface(),
+        )));
+    }
+
+    #[cfg(feature = "unwind_internal")]
+    extensions::unwind_internal::initialize();
+}
+
+/// Fetches a reference to the interface.
+///
+/// Using the interface is safe, as long as a [LockToken] is constructed.
+#[inline]
+pub fn get_interface<'a>() -> &'a CBaseRef<'static> {
+    unsafe { &*INTERFACE.as_ptr() }
+}
+
+/// Fetches a mutable reference to the interface.
+///
+/// Using the interface is safe, as long as a [LockToken] is constructed.
+#[inline]
+pub fn get_mut_interface<'a>() -> &'a mut CBaseRef<'static> {
+    unsafe { &mut *INTERFACE.as_mut_ptr() }
+}

--- a/emf-core-base-rs/src/global/extensions.rs
+++ b/emf-core-base-rs/src/global/extensions.rs
@@ -1,0 +1,4 @@
+//! Extensions
+
+#[cfg(feature = "unwind_internal")]
+pub mod unwind_internal;

--- a/emf-core-base-rs/src/global/extensions/unwind_internal.rs
+++ b/emf-core-base-rs/src/global/extensions/unwind_internal.rs
@@ -1,0 +1,96 @@
+//! The `unwind_internal` extension.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use emf_core_base_rs::global::extensions::unwind_internal::catch_unwind;
+//!
+//! let result = catch_unwind(|| {
+//!     print!("hello");
+//! });
+//! assert!(result.is_ok());
+//!
+//! let result = catch_unwind(|| {
+//!     panic!("oh no!");
+//! });
+//! assert!(result.is_err());
+//! ```
+use super::super::{
+    get_interface as get_base_interface, get_mut_interface as get_mut_base_interface,
+};
+use crate::extensions::unwind_internal::{
+    default_context::DefaultContext, Signal, UnwindInternalAPI, UnwindInternalContextAPI,
+    UnwindInternalContextRef, UnwindInternalInterface,
+};
+use std::mem::MaybeUninit;
+use std::panic::UnwindSafe;
+
+static mut INTERFACE: MaybeUninit<UnwindInternalInterface<'static>> = MaybeUninit::uninit();
+
+/// Initializes the interface.
+#[inline]
+pub fn initialize() {
+    unsafe {
+        INTERFACE = MaybeUninit::new(UnwindInternalInterface::from_interface(get_base_interface()))
+    }
+}
+
+/// Fetches a reference to the interface.
+#[inline]
+pub fn get_interface<'a>() -> &'a UnwindInternalInterface<'static> {
+    unsafe { &*INTERFACE.as_ptr() }
+}
+
+/// Fetches a mutable reference to the interface.
+#[inline]
+pub fn get_mut_interface<'a>() -> &'a mut UnwindInternalInterface<'static> {
+    unsafe { &mut *INTERFACE.as_mut_ptr() }
+}
+
+/// Fetches the active context.
+///
+/// # Return
+///
+/// Active context.
+#[inline]
+pub fn get_context() -> Option<UnwindInternalContextRef> {
+    get_interface().get_context(get_base_interface())
+}
+
+/// Sets the new active context.
+#[inline]
+pub fn set_context(context: Option<UnwindInternalContextRef>) {
+    get_mut_interface().set_context(get_mut_base_interface(), context)
+}
+
+/// Sets up the unwinding for the closure `f`
+///
+/// Any panic or termination signal, that occurs within `f`, is propagated.
+///
+/// # Return
+///
+/// Return value from `f`.
+#[inline]
+pub fn setup_unwind<T>(f: impl FnOnce() -> T + UnwindSafe) -> T {
+    DefaultContext::default().setup_unwind(
+        get_mut_interface(),
+        get_mut_base_interface(),
+        move |_interface| f(),
+    )
+}
+
+/// Sets up the unwinding for the closure `f`
+///
+/// Any panic or termination signal, that occurs within `f`, is caught and returned.
+///
+/// # Return
+///
+/// Return value from `f` or caught signal.
+#[inline]
+pub fn catch_unwind<T>(f: impl FnOnce() -> T + UnwindSafe) -> Result<T, Signal> {
+    DefaultContext::default().catch_unwind(
+        get_mut_interface(),
+        get_mut_base_interface(),
+        move |_interface| f(),
+    )
+}

--- a/emf-core-base-rs/src/global/library.rs
+++ b/emf-core-base-rs/src/global/library.rs
@@ -1,0 +1,365 @@
+//! Global library api.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use emf_core_base_rs::global::{LockToken, Unlock, library};
+//! use emf_core_base_rs::library::{DEFAULT_HANDLE, Symbol};
+//! use std::path::Path;
+//! use std::ffi::CString;
+//!
+//! # use emf_core_base_rs::library::Error;
+//! # fn main() -> Result<(), Error> {
+//! let mut lock = LockToken::<Unlock>::lock();
+//!
+//! let library_path = Path::new("path to my library");
+//! let symbol_name = CString::new("add_function").unwrap();
+//!
+//! let mut  library = library::load(&mut lock, &DEFAULT_HANDLE, &library_path)?;
+//! let symbol: Symbol<extern "C" fn(i32, i32) -> i32> =
+//!     library::get_function_symbol(
+//!         &lock,
+//!         &library,
+//!         &symbol_name,
+//!         |f| unsafe { std::mem::transmute(f) }
+//!     )?;
+//!
+//! assert_eq!(symbol.as_ref()(5, 8), 13);
+//! # Ok(())
+//! # }
+//! ```
+use crate::ffi::collections::NonNullConst;
+use crate::ffi::CBaseFn;
+use crate::global::{get_interface, get_mut_interface, LockToken};
+use crate::library::library_loader::{LibraryLoader, LibraryLoaderABICompat, LibraryLoaderAPI};
+use crate::library::{Error, InternalLibrary, Library, LibraryAPI, LibraryType, Loader, Symbol};
+use crate::ownership::{BorrowMutable, ImmutableAccessIdentifier, MutableAccessIdentifier, Owned};
+use std::ffi::{c_void, CStr};
+use std::path::Path;
+
+/// Registers a new loader.
+///
+/// The loader can load libraries of the type `lib_type`.
+/// The loader must outlive the binding to the interface.
+///
+/// # Failure
+///
+/// The function fails if the library type already exists.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn register_loader<'loader, L, LT, T>(
+    _token: &mut LockToken<L>,
+    loader: &'loader LT,
+    lib_type: &impl AsRef<str>,
+) -> Result<Loader<'static, Owned>, Error>
+where
+    T: LibraryLoaderAPI<'static>,
+    LibraryLoader<T, Owned>: From<&'loader LT>,
+{
+    LibraryAPI::register_loader(get_mut_interface(), loader, lib_type)
+}
+
+/// Unregisters an existing loader.
+///
+/// # Failure
+///
+/// The function fails if `loader` is invalid.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn unregister_loader<L>(
+    _token: &mut LockToken<L>,
+    loader: Loader<'_, Owned>,
+) -> Result<(), Error> {
+    LibraryAPI::unregister_loader(get_mut_interface(), loader)
+}
+
+/// Fetches the interface of a library loader.
+///
+/// # Failure
+///
+/// The function fails if `loader` is invalid.
+///
+/// # Return
+///
+/// Interface on success, error otherwise.
+#[inline]
+pub fn get_loader_interface<'loader, L, O, T>(
+    _token: &mut LockToken<L>,
+    loader: &Loader<'loader, O>,
+) -> Result<LibraryLoader<T, O>, Error>
+where
+    O: ImmutableAccessIdentifier,
+    T: LibraryLoaderAPI<'loader> + LibraryLoaderABICompat,
+{
+    LibraryAPI::get_loader_interface(get_mut_interface(), loader)
+}
+
+/// Fetches the loader handle associated with the library type.
+///
+/// # Failure
+///
+/// The function fails if `lib_type` is not registered.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn get_loader_handle_from_type<'tok, L>(
+    _token: &'tok LockToken<L>,
+    lib_type: &impl AsRef<str>,
+) -> Result<Loader<'static, BorrowMutable<'tok>>, Error> {
+    LibraryAPI::get_loader_handle_from_type(get_interface(), lib_type)
+}
+
+/// Fetches the loader handle linked with the library handle.
+///
+/// # Failure
+///
+/// The function fails if `library` is invalid.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn get_loader_handle_from_library<'l, 'library, L, O>(
+    _token: &'l LockToken<L>,
+    library: &Library<'library, O>,
+) -> Result<Loader<'library, BorrowMutable<'l>>, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    LibraryAPI::get_loader_handle_from_library(get_interface(), library)
+}
+
+/// Fetches the number of registered loaders.
+///
+/// # Return
+///
+/// Number of registered loaders.
+#[inline]
+pub fn get_num_loaders<L>(_token: &LockToken<L>) -> usize {
+    LibraryAPI::get_num_loaders(get_interface())
+}
+
+/// Checks if a the library handle is valid.
+///
+/// # Return
+///
+/// [true] if the handle is valid, [false] otherwise.
+#[inline]
+pub fn library_exists<'library, L, O>(_token: &LockToken<L>, library: &Library<'library, O>) -> bool
+where
+    O: ImmutableAccessIdentifier,
+{
+    LibraryAPI::library_exists(get_interface(), library)
+}
+
+/// Checks if a library type exists.
+///
+/// # Return
+///
+/// [true] if the type exists, [false] otherwise.
+#[inline]
+pub fn type_exists<L>(_token: &LockToken<L>, lib_type: &impl AsRef<str>) -> Result<bool, Error> {
+    LibraryAPI::type_exists(get_interface(), lib_type)
+}
+
+/// Copies the strings of the registered library types into a buffer.
+///
+/// # Failure
+///
+/// The function fails if `buffer.as_ref().len() < get_num_loaders()`.
+///
+/// # Return
+///
+/// Number of written types on success, error otherwise.
+#[inline]
+pub fn get_library_types<L>(
+    _token: &LockToken<L>,
+    buffer: impl AsMut<[LibraryType]>,
+) -> Result<usize, Error> {
+    LibraryAPI::get_library_types(get_interface(), buffer)
+}
+
+/// Creates a new unlinked library handle.
+///
+/// # Return
+///
+/// Library handle.
+///
+/// # Safety
+///
+/// The handle must be linked before use.
+#[inline]
+pub unsafe fn create_library_handle<L>(_token: &mut LockToken<L>) -> Library<'static, Owned> {
+    LibraryAPI::create_library_handle(get_mut_interface())
+}
+
+/// Removes an existing library handle.
+///
+/// # Failure
+///
+/// The function fails if `library` is invalid.
+///
+/// # Return
+///
+/// Error on failure.
+///
+/// # Safety
+///
+/// Removing the handle does not unload the library.
+#[inline]
+pub unsafe fn remove_library_handle<L>(
+    _token: &mut LockToken<L>,
+    library: Library<'_, Owned>,
+) -> Result<(), Error> {
+    LibraryAPI::remove_library_handle(get_mut_interface(), library)
+}
+
+/// Links a library handle to an internal library handle.
+///
+/// Overrides the internal link of the library handle by setting
+/// it to the new library loader and internal handle.
+///
+/// # Failure
+///
+/// The function fails if `library` or `loader` are invalid.
+///
+/// # Return
+///
+/// Error on failure.
+///
+/// # Safety
+///
+/// Incorrect usage can lead to dangling handles or use-after-free errors.
+#[inline]
+pub unsafe fn link_library<'library, 'loader, L, O, LO, IO>(
+    _token: &mut LockToken<L>,
+    library: &Library<'library, O>,
+    loader: &Loader<'loader, LO>,
+    internal: &InternalLibrary<IO>,
+) -> Result<(), Error>
+where
+    'loader: 'library,
+    O: MutableAccessIdentifier,
+    LO: ImmutableAccessIdentifier,
+    IO: ImmutableAccessIdentifier,
+{
+    LibraryAPI::link_library(get_mut_interface(), library, loader, internal)
+}
+
+/// Fetches the internal handle linked with the library handle.
+///
+/// # Failure
+///
+/// The function fails if `handle` is invalid.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn get_internal_library_handle<'library, L, O>(
+    _token: &LockToken<L>,
+    library: &Library<'library, O>,
+) -> Result<InternalLibrary<O>, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    LibraryAPI::get_internal_library_handle(get_interface(), library)
+}
+
+/// Loads a library. The resulting handle is unique.
+///
+/// # Failure
+///
+/// The function fails if `loader` or `path` is invalid or
+/// the type of the library can not be loaded with the loader.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn load<L, O>(
+    _token: &mut LockToken<L>,
+    loader: &Loader<'static, O>,
+    path: &impl AsRef<Path>,
+) -> Result<Library<'static, Owned>, Error>
+where
+    O: MutableAccessIdentifier,
+{
+    LibraryAPI::load(get_mut_interface(), loader, path)
+}
+
+/// Unloads a library.
+///
+/// # Failure
+///
+/// The function fails if `library` is invalid.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn unload<L>(_token: &mut LockToken<L>, library: Library<'_, Owned>) -> Result<(), Error> {
+    LibraryAPI::unload(get_mut_interface(), library)
+}
+
+/// Fetches a data symbol from a library.
+///
+/// # Failure
+///
+/// The function fails if `library` is invalid or library does not contain `symbol`.
+///
+/// # Note
+///
+/// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+/// See [get_function_symbol()] for fetching a function.
+///
+/// # Return
+///
+/// Symbol on success, error otherwise.
+#[inline]
+pub fn get_data_symbol<'library, 'handle, L, O, U>(
+    _token: &LockToken<L>,
+    library: &'handle Library<'library, O>,
+    symbol: &impl AsRef<CStr>,
+    caster: impl FnOnce(NonNullConst<c_void>) -> &'library U,
+) -> Result<Symbol<'handle, &'library U>, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    LibraryAPI::get_data_symbol(get_interface(), library, symbol, caster)
+}
+
+/// Fetches a function symbol from a library.
+///
+/// # Failure
+///
+/// The function fails if `library` is invalid or library does not contain `symbol`.
+///
+/// # Note
+///
+/// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+/// See [get_data_symbol()] for fetching some data.
+///
+/// # Return
+///
+/// Symbol on success, error otherwise.
+#[inline]
+pub fn get_function_symbol<'library, 'handle, L, O, U>(
+    _token: &LockToken<L>,
+    library: &'handle Library<'library, O>,
+    symbol: &impl AsRef<CStr>,
+    caster: impl FnOnce(CBaseFn) -> U,
+) -> Result<Symbol<'handle, U>, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    LibraryAPI::get_function_symbol(get_interface(), library, symbol, caster)
+}

--- a/emf-core-base-rs/src/global/module.rs
+++ b/emf-core-base-rs/src/global/module.rs
@@ -1,0 +1,637 @@
+//! Global module api.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use emf_core_base_rs::global::{LockToken, Unlock, module, version};
+//! use emf_core_base_rs::module::{DEFAULT_HANDLE, InterfaceDescriptor, InterfaceName};
+//! use emf_core_base_rs::ffi::collections::ConstSpan;
+//! use std::path::Path;
+//!
+//! # use emf_core_base_rs::module::Error;
+//! # fn main() -> Result<(), Error> {
+//! let mut lock = LockToken::<Unlock>::lock();
+//!
+//! let module_path = Path::new("path to a module");
+//! let interface_desc = InterfaceDescriptor {
+//!     name: InterfaceName::from("my_interface"),
+//!     version: version::new_short(1, 0, 0),
+//!     extensions: ConstSpan::new()
+//! };
+//!
+//! let mut module = module::add_module(&DEFAULT_HANDLE, &module_path)?;
+//! module::load(&mut module)?;
+//! module::initialize(&mut module)?;
+//! module::export_interface(&mut module, &interface_desc)?;
+//! # Ok(())
+//! # }
+//! ```
+use crate::ffi::library::OSPathChar;
+use crate::global::{get_interface as get_interface_glob, get_mut_interface};
+use crate::module::module_loader::{ModuleLoader, ModuleLoaderABICompat, ModuleLoaderAPI};
+use crate::module::{
+    Error, Interface, InterfaceDescriptor, InternalModule, Loader, Module, ModuleAPI, ModuleInfo,
+    ModuleStatus, ModuleType,
+};
+use crate::ownership::{
+    BorrowImmutable, BorrowMutable, ImmutableAccessIdentifier, MutableAccessIdentifier, Owned,
+};
+use std::path::Path;
+
+/// Registers a new module loader.
+///
+/// Module types starting with `__` are reserved for future use.
+///
+/// # Failure
+///
+/// The function fails if `mod_type` already exists.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn register_loader<'loader, LT, L>(
+    loader: &'loader LT,
+    mod_type: &impl AsRef<str>,
+) -> Result<Loader<'static, Owned>, Error>
+where
+    L: ModuleLoaderAPI<'static>,
+    ModuleLoader<L, Owned>: From<&'loader LT>,
+{
+    ModuleAPI::register_loader(get_mut_interface(), loader, mod_type)
+}
+
+/// Unregisters an existing module loader.
+///
+/// Unregistering a module loader also unloads the modules it loaded.
+///
+/// # Failure
+///
+/// The function fails if `loader` is invalid.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn unregister_loader(loader: Loader<'_, Owned>) -> Result<(), Error> {
+    ModuleAPI::unregister_loader(get_mut_interface(), loader)
+}
+
+/// Fetches the interface of a module loader.
+///
+/// # Failure
+///
+/// The function fails if `loader` is invalid.
+///
+/// # Return
+///
+/// Interface on success, error otherwise.
+#[inline]
+pub fn get_loader_interface<'loader, O, L>(
+    loader: &Loader<'loader, O>,
+) -> Result<ModuleLoader<L, O>, Error>
+where
+    O: ImmutableAccessIdentifier,
+    L: ModuleLoaderAPI<'loader> + ModuleLoaderABICompat,
+{
+    ModuleAPI::get_loader_interface(get_mut_interface(), loader)
+}
+
+/// Fetches the handle of the loader associated with a module type.
+///
+/// # Failure
+///
+/// The function fails if `mod_type` does not exist.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn get_loader_handle_from_type(
+    mod_type: &impl AsRef<str>,
+) -> Result<Loader<'static, BorrowMutable<'_>>, Error> {
+    ModuleAPI::get_loader_handle_from_type(get_interface_glob(), mod_type)
+}
+
+/// Fetches the handle of the loader linked with the module handle.
+///
+/// # Failure
+///
+/// The function fails if `module` is invalid.
+///
+/// # Return
+///
+/// Handle on success, error otherwise.
+#[inline]
+pub fn get_loader_handle_from_module<'m, 'module, O>(
+    module: &'m Module<'module, O>,
+) -> Result<Loader<'module, BorrowMutable<'m>>, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_loader_handle_from_module(get_interface_glob(), module)
+}
+
+/// Fetches the number of loaded modules.
+///
+/// # Return
+///
+/// Number of modules.
+#[inline]
+pub fn get_num_modules() -> usize {
+    ModuleAPI::get_num_modules(get_interface_glob())
+}
+
+/// Fetches the number of loaders.
+///
+/// # Return
+///
+/// Number of module loaders.
+#[inline]
+pub fn get_num_loaders() -> usize {
+    ModuleAPI::get_num_loaders(get_interface_glob())
+}
+
+/// Fetches the number of exported interfaces.
+///
+/// # Return
+///
+/// Number of exported interfaces.
+#[inline]
+pub fn get_num_exported_interfaces() -> usize {
+    ModuleAPI::get_num_exported_interfaces(get_interface_glob())
+}
+
+/// Checks if a module exists.
+///
+/// # Return
+///
+/// [true] if it exists, [false] otherwise.
+#[inline]
+pub fn module_exists<O>(module: &Module<'_, O>) -> bool
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::module_exists(get_interface_glob(), module)
+}
+
+/// Checks if a module type exists.
+///
+/// # Return
+///
+/// [true] if it exists, [false] otherwise.
+#[inline]
+pub fn type_exists(mod_type: &impl AsRef<str>) -> Result<bool, Error> {
+    ModuleAPI::type_exists(get_interface_glob(), mod_type)
+}
+
+/// Checks whether an exported interface exists.
+///
+/// # Return
+///
+/// [true] if it exists, [false] otherwise.
+#[inline]
+pub fn exported_interface_exists(interface: &InterfaceDescriptor) -> bool {
+    ModuleAPI::exported_interface_exists(get_interface_glob(), interface)
+}
+
+/// Copies the available module info into a buffer.
+///
+/// # Failure
+///
+/// Fails if `buffer.as_ref().len() < get_num_modules()`.
+///
+/// # Return
+///
+/// Number if written module info on success, error otherwise.
+#[inline]
+pub fn get_modules(buffer: &mut impl AsMut<[ModuleInfo]>) -> Result<usize, Error> {
+    ModuleAPI::get_modules(get_interface_glob(), buffer)
+}
+
+/// Copies the available module types into a buffer.
+///
+/// # Failure
+///
+/// Fails if `buffer.as_ref().len() < get_num_loaders()`.
+///
+/// # Return
+///
+/// Number if written module types on success, error otherwise.
+#[inline]
+pub fn get_module_types(buffer: &mut impl AsMut<[ModuleType]>) -> Result<usize, Error> {
+    ModuleAPI::get_module_types(get_interface_glob(), buffer)
+}
+
+/// Copies the descriptors of the exported interfaces into a buffer.
+///
+/// # Failure
+///
+/// Fails if `buffer.as_ref().len() < get_num_exported_interfaces()`.
+///
+/// # Return
+///
+/// Number if written descriptors on success, error otherwise.
+#[inline]
+pub fn get_exported_interfaces(
+    buffer: &mut impl AsMut<[InterfaceDescriptor]>,
+) -> Result<usize, Error> {
+    ModuleAPI::get_exported_interfaces(get_interface_glob(), buffer)
+}
+
+/// Fetches the module handle of the exported interface.
+///
+/// # Failure
+///
+/// Fails if `interface` does not exist.
+///
+/// # Return
+///
+/// Module handle on success, error otherwise.
+#[inline]
+pub fn get_exported_interface_handle(
+    interface: &InterfaceDescriptor,
+) -> Result<Module<'static, BorrowImmutable<'_>>, Error> {
+    ModuleAPI::get_exported_interface_handle(get_interface_glob(), interface)
+}
+
+/// Creates a new unlinked module handle.
+///
+/// # Return
+///
+/// Module handle.
+///
+/// # Safety
+///
+/// The handle remains invalid until it's linked with [link_module].
+#[inline]
+pub unsafe fn create_module_handle() -> Module<'static, Owned> {
+    ModuleAPI::create_module_handle(get_mut_interface())
+}
+
+/// Links a module handle to an internal module handle.
+///
+/// # Failure
+///
+/// Fails if `module` or`loader` are invalid.
+///
+/// # Return
+///
+/// Error on failure.
+///
+/// # Safety
+///
+/// Removing the handle does not unload the module.
+#[inline]
+pub unsafe fn remove_module_handle(module: Module<'_, Owned>) -> Result<(), Error> {
+    ModuleAPI::remove_module_handle(get_mut_interface(), module)
+}
+
+/// Links a module handle to an internal module handle.
+///
+/// # Failure
+///
+/// Fails if `module` or`loader` are invalid.
+///
+/// # Return
+///
+/// Error on failure.
+///
+/// # Safety
+///
+/// Incorrect usage can lead to dangling handles or use-after-free errors.
+#[inline]
+pub unsafe fn link_module<'module, 'loader, O, LO, IO>(
+    module: &Module<'module, O>,
+    loader: &Loader<'loader, LO>,
+    internal: &InternalModule<IO>,
+) -> Result<(), Error>
+where
+    'loader: 'module,
+    O: MutableAccessIdentifier,
+    LO: ImmutableAccessIdentifier,
+    IO: ImmutableAccessIdentifier,
+{
+    ModuleAPI::link_module(get_mut_interface(), module, loader, internal)
+}
+
+/// Fetches the internal handle linked with the module handle.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid.
+///
+/// # Return
+///
+/// Internal handle on success, error otherwise.
+#[inline]
+pub fn get_internal_module_handle<O>(module: &Module<'_, O>) -> Result<InternalModule<O>, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_internal_module_handle(get_interface_glob(), module)
+}
+
+/// Adds a new module.
+///
+/// # Failure
+///
+/// Fails if `loader` or `path` is invalid or the type
+/// of the module can not be loaded with the loader.
+///
+/// # Return
+///
+/// Module handle on success, error otherwise.
+#[inline]
+pub fn add_module<O>(
+    loader: &Loader<'static, O>,
+    path: &impl AsRef<Path>,
+) -> Result<Module<'static, Owned>, Error>
+where
+    O: MutableAccessIdentifier,
+{
+    ModuleAPI::add_module(get_mut_interface(), loader, path)
+}
+
+/// Removes a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid or the module is not in an unloaded state.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn remove_module(module: Module<'_, Owned>) -> Result<(), Error> {
+    ModuleAPI::remove_module(get_mut_interface(), module)
+}
+
+/// Loads a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid, the load dependencies of the module are
+/// not exported or the module is not in an unloaded state.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn load<O>(module: &mut Module<'_, O>) -> Result<(), Error>
+where
+    O: MutableAccessIdentifier,
+{
+    ModuleAPI::load(get_mut_interface(), module)
+}
+
+/// Unloads a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid or the module is in an unloaded or ready state.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn unload<O>(module: &mut Module<'_, O>) -> Result<(), Error>
+where
+    O: MutableAccessIdentifier,
+{
+    ModuleAPI::unload(get_mut_interface(), module)
+}
+
+/// Initializes a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid, the runtime dependencies of the
+/// module are not exported or the module is not in a loaded state.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn initialize<O>(module: &mut Module<'_, O>) -> Result<(), Error>
+where
+    O: MutableAccessIdentifier,
+{
+    ModuleAPI::initialize(get_mut_interface(), module)
+}
+
+/// Terminates a module.
+///
+/// Terminating a module also removes the interfaces it exported.
+/// The modules that depend on the module are terminated.
+/// If they list the module as a load dependency, they are also unloaded.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid or the module is not in a ready state.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn terminate<O>(module: &mut Module<'_, O>) -> Result<(), Error>
+where
+    O: MutableAccessIdentifier,
+{
+    ModuleAPI::terminate(get_mut_interface(), module)
+}
+
+/// Registers a new runtime dependency of the module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn add_dependency<O>(
+    module: &mut Module<'_, O>,
+    interface: &InterfaceDescriptor,
+) -> Result<(), Error>
+where
+    O: MutableAccessIdentifier,
+{
+    ModuleAPI::add_dependency(get_mut_interface(), module, interface)
+}
+
+/// Removes an existing runtime dependency from the module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn remove_dependency<O>(
+    module: &mut Module<'_, O>,
+    interface: &InterfaceDescriptor,
+) -> Result<(), Error>
+where
+    O: MutableAccessIdentifier,
+{
+    ModuleAPI::remove_dependency(get_mut_interface(), module, interface)
+}
+
+/// Exports an interface of a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid, `interface` is already exported,
+/// `interface` is not contained in the module or the module is not yet initialized.
+///
+/// # Return
+///
+/// Error on failure.
+#[inline]
+pub fn export_interface<O>(
+    module: &Module<'_, O>,
+    interface: &InterfaceDescriptor,
+) -> Result<(), Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::export_interface(get_mut_interface(), module, interface)
+}
+
+/// Fetches the load dependencies of a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid.
+///
+/// # Return
+///
+/// Load dependencies on success, error otherwise.
+#[inline]
+pub fn get_load_dependencies<'module, O>(
+    module: &Module<'module, O>,
+) -> Result<&'module [InterfaceDescriptor], Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_load_dependencies(get_interface_glob(), module)
+}
+
+/// Fetches the runtime dependencies of a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid or the module is not yet loaded.
+///
+/// # Return
+///
+/// Runtime dependencies on success, error otherwise.
+#[inline]
+pub fn get_runtime_dependencies<'module, O>(
+    module: &Module<'module, O>,
+) -> Result<&'module [InterfaceDescriptor], Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_runtime_dependencies(get_interface_glob(), module)
+}
+
+/// Fetches the exportable interfaces of a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid or the module is not yet loaded.
+///
+/// # Return
+///
+/// Exportable interfaces on success, error otherwise.
+#[inline]
+pub fn get_exportable_interfaces<'module, O>(
+    module: &Module<'module, O>,
+) -> Result<&'module [InterfaceDescriptor], Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_exportable_interfaces(get_interface_glob(), module)
+}
+
+/// Fetches the load status of a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid.
+///
+/// # Return
+///
+/// Module status on success, error otherwise.
+#[inline]
+pub fn fetch_status<O>(module: &Module<'_, O>) -> Result<ModuleStatus, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::fetch_status(get_interface_glob(), module)
+}
+
+/// Fetches the path a module was loaded from.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid or the module is not yet loaded.
+///
+/// # Return
+///
+/// Module path on success, error otherwise.
+#[inline]
+pub fn get_module_path<'module, O>(
+    module: &Module<'module, O>,
+) -> Result<&'module [OSPathChar], Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_module_path(get_interface_glob(), module)
+}
+
+/// Fetches the module info from a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid or the module is not yet loaded.
+///
+/// # Return
+///
+/// Module info on success, error otherwise.
+#[inline]
+pub fn get_module_info<'module, O>(
+    module: &Module<'module, O>,
+) -> Result<&'module ModuleInfo, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_module_info(get_interface_glob(), module)
+}
+
+/// Fetches an interface from a module.
+///
+/// # Failure
+///
+/// Fails if `module` is invalid, the module is not in a ready
+/// state or the interface is not contained in the module.
+///
+/// # Return
+///
+/// Interface on success, error otherwise.
+#[inline]
+pub fn get_interface<'module, O, T>(
+    module: &'module Module<'_, O>,
+    interface: &InterfaceDescriptor,
+    caster: impl FnOnce(crate::ffi::module::Interface) -> T,
+) -> Result<Interface<'module, T>, Error>
+where
+    O: ImmutableAccessIdentifier,
+{
+    ModuleAPI::get_interface(get_interface_glob(), module, interface, caster)
+}

--- a/emf-core-base-rs/src/global/sys.rs
+++ b/emf-core-base-rs/src/global/sys.rs
@@ -1,0 +1,86 @@
+//! Global sys api.
+use crate::fn_caster::FnCaster;
+use crate::global::{get_interface, get_mut_interface, LockToken};
+use crate::sys::sync_handler::SyncHandlerAPI;
+use crate::sys::{SysAPI, SysAPIMin};
+use std::ffi::CStr;
+
+/// Execution of the program is stopped abruptly. The error may be logged.
+#[inline]
+pub fn panic(error: Option<impl AsRef<CStr>>) -> ! {
+    SysAPIMin::panic(get_interface(), error)
+}
+
+/// Sends a termination signal.
+#[inline]
+pub fn shutdown<L>(_token: &mut LockToken<L>) -> ! {
+    SysAPI::shutdown(get_mut_interface())
+}
+
+/// Checks if a function is implemented.
+///
+/// # Return
+///
+/// Returns [true] if the function exists, [false] otherwise.
+#[inline]
+pub fn has_function<U>() -> bool
+where
+    U: FnCaster,
+{
+    SysAPIMin::has_function::<U>(get_interface())
+}
+
+/// Fetches a function from the interface.
+///
+/// # Return
+///
+/// Function casted to the appropriate type.
+#[inline]
+pub fn get_function<U>(caster: &U) -> Option<<U as FnCaster>::Type>
+where
+    U: FnCaster,
+{
+    SysAPIMin::get_function::<U>(get_interface(), caster)
+}
+
+/// Fetches the active synchronization handler.
+///
+/// # Return
+///
+/// The active synchronization handler.
+#[inline]
+pub fn get_sync_handler<L, U>(_token: &LockToken<L>) -> <U as SyncHandlerAPI<'static>>::Handler
+where
+    U: SyncHandlerAPI<'static>,
+{
+    SysAPI::get_sync_handler::<U>(get_interface())
+}
+
+/// Sets a new synchronization handler.
+///
+/// The default synchronization handler is used, if `handler` is [Option::None].
+///
+/// # Uses
+///
+/// This function can be used by modules, that want to provide a more complex
+/// synchronization mechanism than the one presented by the default handler.
+///
+/// # Swapping
+///
+/// The swapping occurs in three steps:
+///
+/// 1. The new synchronization handler is locked.
+/// 2. The new synchronization handler is set as the active synchronization handler.
+/// 3. The old synchronization handler is unlocked.
+///
+/// # Safety
+///
+/// Changing the synchronization handler may break some modules,
+/// if they depend on a specific synchronization handler.
+#[inline]
+pub unsafe fn set_sync_handler<L>(
+    _token: &mut LockToken<L>,
+    handler: Option<&impl SyncHandlerAPI<'static>>,
+) {
+    SysAPI::set_sync_handler(get_mut_interface(), handler)
+}

--- a/emf-core-base-rs/src/global/version.rs
+++ b/emf-core-base-rs/src/global/version.rs
@@ -1,0 +1,217 @@
+//! Global version api.
+use crate::ffi::version::Version;
+use crate::global::get_interface;
+use crate::version::{Error, ReleaseType, VersionAPI};
+use std::cmp::Ordering;
+
+/// Constructs a new version.
+///
+/// Constructs a new version with `major`, `minor` and `patch` and sets the rest to `0`.
+///
+/// # Return
+///
+/// Constructed version.
+#[inline]
+pub fn new_short(major: i32, minor: i32, patch: i32) -> Version {
+    VersionAPI::new_short(get_interface(), major, minor, patch)
+}
+
+/// Constructs a new version.
+///
+/// Constructs a new version with `major`, `minor`, `patch`, `release_type` and
+/// `release_number` and sets the rest to `0`.
+///
+/// # Return
+///
+/// Constructed version.
+#[inline]
+pub fn new_long(
+    major: i32,
+    minor: i32,
+    patch: i32,
+    release_type: ReleaseType,
+    release_number: i8,
+) -> Version {
+    VersionAPI::new_long(
+        get_interface(),
+        major,
+        minor,
+        patch,
+        release_type,
+        release_number,
+    )
+}
+
+/// Constructs a new version.
+///
+/// Constructs a new version with `major`, `minor`, `patch`, `release_type`,
+/// `release_number` and `build`.
+///
+/// # Return
+///
+/// Constructed version.
+#[inline]
+pub fn new_full(
+    major: i32,
+    minor: i32,
+    patch: i32,
+    release_type: ReleaseType,
+    release_number: i8,
+    build: i64,
+) -> Version {
+    VersionAPI::new_full(
+        get_interface(),
+        major,
+        minor,
+        patch,
+        release_type,
+        release_number,
+        build,
+    )
+}
+
+/// Constructs a version from a string.
+///
+/// # Failure
+///
+/// Fails if `string_is_valid(buffer) == false`.
+///
+/// # Return
+///
+/// Constructed version.
+#[inline]
+pub fn from_string(buffer: impl AsRef<str>) -> Result<Version, Error> {
+    VersionAPI::from_string(get_interface(), buffer)
+}
+
+/// Computes the length of the short version string.
+///
+/// # Return
+///
+/// Length of the string.
+#[inline]
+pub fn string_length_short(version: &Version) -> usize {
+    VersionAPI::string_length_short(get_interface(), version)
+}
+
+/// Computes the length of the long version string.
+///
+/// # Return
+///
+/// Length of the string.
+#[inline]
+pub fn string_length_long(version: &Version) -> usize {
+    VersionAPI::string_length_long(get_interface(), version)
+}
+
+/// Computes the length of the full version string.
+///
+/// # Return
+///
+/// Length of the string.
+#[inline]
+pub fn string_length_full(version: &Version) -> usize {
+    VersionAPI::string_length_full(get_interface(), version)
+}
+
+/// Represents the version as a short string.
+///
+/// # Failure
+///
+/// This function fails if `buffer.len() < string_length_short(version)`.
+///
+/// # Return
+///
+/// Number of written characters on success, error otherwise.
+#[inline]
+pub fn as_string_short(version: &Version, buffer: impl AsMut<str>) -> Result<usize, Error> {
+    VersionAPI::as_string_short(get_interface(), version, buffer)
+}
+
+/// Represents the version as a long string.
+///
+/// # Failure
+///
+/// This function fails if `buffer.len() < string_length_long(version)`.
+///
+/// # Return
+///
+/// Number of written characters on success, error otherwise.
+#[inline]
+pub fn as_string_long(version: &Version, buffer: impl AsMut<str>) -> Result<usize, Error> {
+    VersionAPI::as_string_long(get_interface(), version, buffer)
+}
+
+/// Represents the version as a full string.
+///
+/// # Failure
+///
+/// This function fails if `buffer.len() < string_length_full(version)`.
+///
+/// # Return
+///
+/// Number of written characters on success, error otherwise.
+#[inline]
+pub fn as_string_full(version: &Version, buffer: impl AsMut<str>) -> Result<usize, Error> {
+    VersionAPI::as_string_full(get_interface(), version, buffer)
+}
+
+/// Checks whether the version string is valid.
+///
+/// # Return
+///
+/// [true] if the string is valid, [false] otherwise.
+#[inline]
+pub fn string_is_valid(version_string: impl AsRef<str>) -> bool {
+    VersionAPI::string_is_valid(get_interface(), version_string)
+}
+
+/// Compares two versions.
+///
+/// Compares two version, disregarding their build number.
+///
+/// # Return
+///
+/// Order of the versions.
+#[inline]
+pub fn compare(lhs: &Version, rhs: &Version) -> Ordering {
+    VersionAPI::compare(get_interface(), lhs, rhs)
+}
+
+/// Compares two versions.
+///
+/// Compares two version, disregarding their build number and release type.
+///
+/// # Return
+///
+/// Order of the versions.
+#[inline]
+pub fn compare_weak(lhs: &Version, rhs: &Version) -> Ordering {
+    VersionAPI::compare_weak(get_interface(), lhs, rhs)
+}
+
+/// Compares two versions.
+///
+/// # Return
+///
+/// Order of the versions.
+#[inline]
+pub fn compare_strong(lhs: &Version, rhs: &Version) -> Ordering {
+    VersionAPI::compare_strong(get_interface(), lhs, rhs)
+}
+
+/// Checks for compatibility of two versions.
+///
+/// Two compatible versions can be used interchangeably.
+///
+/// # Note
+///
+/// This function is not commutative.
+///
+/// # Return
+///
+/// [true] if the versions are compatible, [false] otherwise.
+#[inline]
+pub fn is_compatible(lhs: &Version, rhs: &Version) -> bool {
+    VersionAPI::is_compatible(get_interface(), lhs, rhs)
+}

--- a/emf-core-base-rs/src/init.rs
+++ b/emf-core-base-rs/src/init.rs
@@ -1,0 +1,39 @@
+use crate::ffi::{
+    sys::api::GetFunctionFn as GetFunctionFnFFI, CBase as CBaseFFI, CBaseInterface, CBaseLoader,
+};
+use crate::{CBase, CBaseAccess, CBaseRef};
+use std::ptr::NonNull;
+
+/// Trait for loading the interface.
+pub trait CBaseAPILoader<'interface> {
+    /// Type of the interface.
+    type Interface: CBaseAccess<'interface>;
+
+    /// Fetches the `emf-core-base` interface.
+    ///
+    /// # Safety
+    ///
+    /// The parameter `get_function_fn` must be able to accept `base_module`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if it can not fetch the interface.
+    unsafe fn fetch_interface(
+        base_module: Option<NonNull<CBaseFFI>>,
+        get_function_fn: GetFunctionFnFFI,
+    ) -> Self::Interface;
+}
+
+impl<'interface> CBaseAPILoader<'interface> for CBase<'interface> {
+    type Interface = Self;
+
+    unsafe fn fetch_interface(
+        base_module: Option<NonNull<CBaseFFI>>,
+        get_function_fn: GetFunctionFnFFI,
+    ) -> Self::Interface {
+        Self::new(CBaseRef::new(CBaseInterface::fetch_interface(
+            base_module,
+            get_function_fn,
+        )))
+    }
+}

--- a/emf-core-base-rs/src/lib.rs
+++ b/emf-core-base-rs/src/lib.rs
@@ -1,0 +1,36 @@
+//! Idiomatic Rust bindings to the `emf-core-base` interface.
+//!
+//! This crate provides the function and type definitions of the
+//! [emf-core-base](https://github.com/fimoengine/emf/tree/main/emf_core_base) interface.
+#![feature(c_unwind)]
+#![feature(const_fn)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    missing_debug_implementations,
+    broken_intra_doc_links
+)]
+pub use emf_core_base_rs_ffi as ffi;
+
+mod cbase;
+mod to_os_path_buff;
+
+#[cfg(feature = "init")]
+mod init;
+
+pub mod fn_caster;
+pub mod library;
+pub mod module;
+pub mod ownership;
+pub mod sys;
+pub mod version;
+
+#[cfg(feature = "global_api")]
+pub mod global;
+
+#[cfg(feature = "extensions")]
+pub mod extensions;
+
+pub use cbase::{CBase, CBaseAPI, CBaseAccess, CBaseInterfaceInfo, CBaseRef};
+pub use init::CBaseAPILoader;
+pub use to_os_path_buff::ToOsPathBuff;

--- a/emf-core-base-rs/src/library.rs
+++ b/emf-core-base-rs/src/library.rs
@@ -1,0 +1,232 @@
+//! Library api
+//!
+//! # Example
+//!
+//! ```no_run
+//! # use emf_core_base_rs::{CBaseAccess, CBase};
+//! # let base_interface: &mut CBase = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+//! use emf_core_base_rs::CBaseAPI;
+//! use emf_core_base_rs::library::{LibraryAPI, DEFAULT_HANDLE, Symbol, Error};
+//! use std::path::Path;
+//! use std::ffi::CString;
+//!
+//! let result = CBaseAccess::lock(base_interface, |interface| -> Result<i32, Error> {
+//!     let library_path = Path::new("path to my library");
+//!     let symbol_name = CString::new("add_function").unwrap();
+//!
+//!     let library = LibraryAPI::load(interface, &DEFAULT_HANDLE, &library_path)?;
+//!     let symbol: Symbol<extern "C" fn(i32, i32) -> i32> =
+//!         LibraryAPI::get_function_symbol(
+//!             interface,
+//!             &library,
+//!             &symbol_name,
+//!             |f| unsafe { std::mem::transmute(f) }
+//!         )?;
+//!
+//!     let result = symbol.as_ref()(5, 8);
+//!     LibraryAPI::unload(interface, library)?;
+//!     Ok(result)
+//! });
+//!
+//! assert_eq!(result.is_ok(), true);
+//! assert_eq!(result.unwrap(), 13);
+//! ```
+use crate::ffi::library::{InternalHandle, LibraryHandle, LoaderHandle};
+use crate::ownership::{AccessIdentifier, BorrowImmutable, BorrowMutable, Owned};
+use std::marker::PhantomData;
+
+mod api;
+pub mod library_loader;
+
+pub use crate::ffi::library::LibraryType;
+pub use crate::ffi::library::LOADER_TYPE_MAX_LENGTH;
+pub use crate::ffi::library::NATIVE_LIBRARY_TYPE_NAME;
+
+pub use api::LibraryAPI;
+
+/// Handle of the default loader.
+pub const DEFAULT_HANDLE: Loader<'static, BorrowMutable<'static>> =
+    unsafe { Loader::new(crate::ffi::library::DEFAULT_HANDLE) };
+
+/// Errors of the library api.
+#[non_exhaustive]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub enum Error {
+    /// Error denoting an invalid library type.
+    InvalidLibraryType(String),
+    /// Raw ffi library error.
+    FFIError(crate::ffi::library::Error),
+}
+
+/// A library handle.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Library<'a, O> {
+    _handle: LibraryHandle,
+    _lifetime: PhantomData<&'a LibraryHandle>,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<'a, O> Library<'a, O>
+where
+    O: AccessIdentifier,
+{
+    /// Construct a new instance from a handle.
+    ///
+    /// # Safety
+    ///
+    /// This function allows the creation of invalid handles
+    /// by bypassing lifetimes.
+    #[inline]
+    pub const unsafe fn new(handle: LibraryHandle) -> Self {
+        Self {
+            _handle: handle,
+            _lifetime: PhantomData,
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Fetches the internal handle.
+    #[inline]
+    pub const fn as_handle(&self) -> LibraryHandle {
+        self._handle
+    }
+}
+
+impl<'a> Library<'a, Owned> {
+    /// Borrows the library handle.
+    #[inline]
+    pub const fn as_borrowed(&self) -> Library<'a, BorrowImmutable<'_>> {
+        unsafe { Library::<BorrowImmutable<'_>>::new(self._handle) }
+    }
+
+    /// Borrows the library handle mutably.
+    #[inline]
+    pub fn as_borrowed_mut(&mut self) -> Library<'a, BorrowMutable<'_>> {
+        unsafe { Library::<BorrowMutable<'_>>::new(self._handle) }
+    }
+}
+
+/// A loader handle.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Loader<'a, O> {
+    _handle: LoaderHandle,
+    _lifetime: PhantomData<&'a LoaderHandle>,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<'a, O> Loader<'a, O>
+where
+    O: AccessIdentifier,
+{
+    /// Construct a new instance from a handle.
+    ///
+    /// # Safety
+    ///
+    /// This function allows the creation of invalid handles
+    /// by bypassing lifetimes.
+    #[inline]
+    pub const unsafe fn new(handle: LoaderHandle) -> Self {
+        Self {
+            _handle: handle,
+            _lifetime: PhantomData,
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Fetches the internal handle.
+    #[inline]
+    pub const fn as_handle(&self) -> LoaderHandle {
+        self._handle
+    }
+}
+
+impl<'a> Loader<'a, Owned> {
+    /// Borrows the loader handle.
+    #[inline]
+    pub const fn as_borrowed(&self) -> Loader<'a, BorrowImmutable<'_>> {
+        unsafe { Loader::<BorrowImmutable<'_>>::new(self._handle) }
+    }
+
+    /// Borrows the loader handle mutably.
+    #[inline]
+    pub fn as_borrowed_mut(&mut self) -> Loader<'a, BorrowMutable<'_>> {
+        unsafe { Loader::<BorrowMutable<'_>>::new(self._handle) }
+    }
+}
+
+/// A loader handle.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct InternalLibrary<O> {
+    _handle: InternalHandle,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<O> InternalLibrary<O>
+where
+    O: AccessIdentifier,
+{
+    /// Construct a new instance from a handle.
+    ///
+    /// # Safety
+    ///
+    /// This function allows the creation of invalid handles
+    /// by bypassing lifetimes.
+    #[inline]
+    pub const unsafe fn new(handle: InternalHandle) -> Self {
+        Self {
+            _handle: handle,
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Fetches the internal handle.
+    #[inline]
+    pub const fn as_handle(&self) -> InternalHandle {
+        self._handle
+    }
+}
+
+impl InternalLibrary<Owned> {
+    /// Borrows the loader handle.
+    #[inline]
+    pub const fn as_borrowed(&self) -> InternalLibrary<BorrowImmutable<'_>> {
+        unsafe { InternalLibrary::<BorrowImmutable<'_>>::new(self._handle) }
+    }
+
+    /// Borrows the loader handle mutably.
+    #[inline]
+    pub fn as_borrowed_mut(&mut self) -> InternalLibrary<BorrowMutable<'_>> {
+        unsafe { InternalLibrary::<BorrowMutable<'_>>::new(self._handle) }
+    }
+}
+
+/// A library symbol.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Symbol<'a, T> {
+    _symbol: T,
+    _phantom: PhantomData<&'a ()>,
+}
+
+impl<T> Symbol<'_, T> {
+    #[inline]
+    fn new(symbol: T) -> Self {
+        Self {
+            _symbol: symbol,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> AsRef<T> for Symbol<'_, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        &self._symbol
+    }
+}
+
+impl<T> AsRef<T> for Symbol<'_, &T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self._symbol
+    }
+}

--- a/emf-core-base-rs/src/library/api.rs
+++ b/emf-core-base-rs/src/library/api.rs
@@ -1,0 +1,522 @@
+use crate::ffi::collections::{MutSpan, NonNullConst};
+use crate::ffi::library::api::LibraryBinding;
+use crate::ffi::{Bool, CBaseFn};
+use crate::library::library_loader::{LibraryLoader, LibraryLoaderABICompat, LibraryLoaderAPI};
+use crate::library::{
+    Error, InternalLibrary, Library, LibraryType, Loader, Symbol, LOADER_TYPE_MAX_LENGTH,
+};
+use crate::ownership::{BorrowMutable, ImmutableAccessIdentifier, MutableAccessIdentifier, Owned};
+use crate::ToOsPathBuff;
+use std::ffi::{c_void, CStr};
+use std::path::Path;
+use std::ptr::NonNull;
+
+/// Idiomatic library api.
+pub trait LibraryAPI<'interface> {
+    /// Registers a new loader.
+    ///
+    /// The loader can load libraries of the type `lib_type`.
+    /// The loader must outlive the binding to the interface.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if the library type already exists.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn register_loader<'loader, LT, L>(
+        &mut self,
+        loader: &'loader LT,
+        lib_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, Owned>, Error>
+    where
+        L: LibraryLoaderAPI<'static>,
+        LibraryLoader<L, Owned>: From<&'loader LT>;
+
+    /// Unregisters an existing loader.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `loader` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn unregister_loader(&mut self, loader: Loader<'_, Owned>) -> Result<(), Error>;
+
+    /// Fetches the interface of a library loader.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `loader` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Interface on success, error otherwise.
+    fn get_loader_interface<'loader, O, L>(
+        &mut self,
+        loader: &Loader<'loader, O>,
+    ) -> Result<LibraryLoader<L, O>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+        L: LibraryLoaderAPI<'loader> + LibraryLoaderABICompat;
+
+    /// Fetches the loader handle associated with the library type.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `lib_type` is not registered.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn get_loader_handle_from_type(
+        &self,
+        lib_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, BorrowMutable<'_>>, Error>;
+
+    /// Fetches the loader handle linked with the library handle.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `library` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn get_loader_handle_from_library<'library, O>(
+        &self,
+        library: &Library<'library, O>,
+    ) -> Result<Loader<'library, BorrowMutable<'_>>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the number of registered loaders.
+    ///
+    /// # Return
+    ///
+    /// Number of registered loaders.
+    fn get_num_loaders(&self) -> usize;
+
+    /// Checks if a the library handle is valid.
+    ///
+    /// # Return
+    ///
+    /// [true] if the handle is valid, [false] otherwise.
+    fn library_exists<'library, O>(&self, library: &Library<'library, O>) -> bool
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Checks if a library type exists.
+    ///
+    /// # Return
+    ///
+    /// [true] if the type exists, [false] otherwise.
+    fn type_exists(&self, lib_type: &impl AsRef<str>) -> Result<bool, Error>;
+
+    /// Copies the strings of the registered library types into a buffer.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `buffer.as_ref().len() < get_num_loaders()`.
+    ///
+    /// # Return
+    ///
+    /// Number of written types on success, error otherwise.
+    fn get_library_types(&self, buffer: impl AsMut<[LibraryType]>) -> Result<usize, Error>;
+
+    /// Creates a new unlinked library handle.
+    ///
+    /// # Return
+    ///
+    /// Library handle.
+    ///
+    /// # Safety
+    ///
+    /// The handle must be linked before use.
+    unsafe fn create_library_handle(&mut self) -> Library<'interface, Owned>;
+
+    /// Removes an existing library handle.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `library` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// Removing the handle does not unload the library.
+    unsafe fn remove_library_handle(&mut self, library: Library<'_, Owned>) -> Result<(), Error>;
+
+    /// Links a library handle to an internal library handle.
+    ///
+    /// Overrides the internal link of the library handle by setting
+    /// it to the new library loader and internal handle.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `library` or `loader` are invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// Incorrect usage can lead to dangling handles or use-after-free errors.
+    unsafe fn link_library<'library, 'loader, O, LO, IO>(
+        &mut self,
+        library: &Library<'library, O>,
+        loader: &Loader<'loader, LO>,
+        internal: &InternalLibrary<IO>,
+    ) -> Result<(), Error>
+    where
+        'loader: 'library,
+        O: MutableAccessIdentifier,
+        LO: ImmutableAccessIdentifier,
+        IO: ImmutableAccessIdentifier;
+
+    /// Fetches the internal handle linked with the library handle.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `handle` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn get_internal_library_handle<'library, O>(
+        &self,
+        library: &Library<'library, O>,
+    ) -> Result<InternalLibrary<O>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Loads a library. The resulting handle is unique.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `loader` or `path` is invalid or
+    /// the type of the library can not be loaded with the loader.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn load<O>(
+        &mut self,
+        loader: &Loader<'interface, O>,
+        path: &impl AsRef<Path>,
+    ) -> Result<Library<'interface, Owned>, Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Unloads a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `library` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn unload(&mut self, library: Library<'_, Owned>) -> Result<(), Error>;
+
+    /// Fetches a data symbol from a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `library` is invalid or library does not contain `symbol`.
+    ///
+    /// # Note
+    ///
+    /// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+    /// See [LibraryAPI::get_function_symbol()] for fetching a function.
+    ///
+    /// # Return
+    ///
+    /// Symbol on success, error otherwise.
+    fn get_data_symbol<'library, 'handle, O, U>(
+        &self,
+        library: &'handle Library<'library, O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(NonNullConst<c_void>) -> &'library U,
+    ) -> Result<Symbol<'handle, &'library U>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches a function symbol from a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `library` is invalid or library does not contain `symbol`.
+    ///
+    /// # Note
+    ///
+    /// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+    /// See [LibraryAPI::get_data_symbol()] for fetching some data.
+    ///
+    /// # Return
+    ///
+    /// Symbol on success, error otherwise.
+    fn get_function_symbol<'library, 'handle, O, U>(
+        &self,
+        library: &'handle Library<'library, O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(CBaseFn) -> U,
+    ) -> Result<Symbol<'handle, U>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+}
+
+impl<'interface, T> LibraryAPI<'interface> for T
+where
+    T: LibraryBinding,
+{
+    #[inline]
+    fn register_loader<'loader, LT, L>(
+        &mut self,
+        loader: &'loader LT,
+        lib_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, Owned>, Error>
+    where
+        L: LibraryLoaderAPI<'static>,
+        LibraryLoader<L, Owned>: From<&'loader LT>,
+    {
+        let lib_str = lib_type.as_ref();
+        if lib_str.as_bytes().len() > LOADER_TYPE_MAX_LENGTH {
+            return Err(Error::InvalidLibraryType(String::from(lib_str)));
+        }
+
+        let lib_type = LibraryType::from(lib_str);
+
+        unsafe {
+            self.register_loader(
+                LibraryLoader::<L, Owned>::from(loader).to_interface(),
+                NonNullConst::from(&lib_type),
+            )
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Loader::new(v)))
+        }
+    }
+
+    #[inline]
+    fn unregister_loader(&mut self, loader: Loader<'_, Owned>) -> Result<(), Error> {
+        unsafe {
+            self.unregister_loader(loader.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn get_loader_interface<'loader, O, L>(
+        &mut self,
+        loader: &Loader<'loader, O>,
+    ) -> Result<LibraryLoader<L, O>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+        L: LibraryLoaderAPI<'loader> + LibraryLoaderABICompat,
+    {
+        unsafe {
+            self.get_loader_interface(loader.as_handle())
+                .to_result()
+                .map_or_else(
+                    |e| Err(Error::FFIError(e)),
+                    |v| Ok(LibraryLoader::from_interface(v)),
+                )
+        }
+    }
+
+    #[inline]
+    fn get_loader_handle_from_type(
+        &self,
+        lib_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, BorrowMutable<'_>>, Error> {
+        let lib_str = lib_type.as_ref();
+        if lib_str.as_bytes().len() > LOADER_TYPE_MAX_LENGTH {
+            return Err(Error::InvalidLibraryType(String::from(lib_str)));
+        }
+
+        let lib_type = LibraryType::from(lib_str);
+
+        unsafe {
+            self.get_loader_handle_from_type(NonNullConst::from(&lib_type))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Loader::new(v)))
+        }
+    }
+
+    #[inline]
+    fn get_loader_handle_from_library<'library, O>(
+        &self,
+        library: &Library<'library, O>,
+    ) -> Result<Loader<'library, BorrowMutable<'_>>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_loader_handle_from_library(library.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Loader::new(v)))
+        }
+    }
+
+    #[inline]
+    fn get_num_loaders(&self) -> usize {
+        unsafe { self.get_num_loaders() }
+    }
+
+    #[inline]
+    fn library_exists<'library, O>(&self, library: &Library<'library, O>) -> bool
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe { self.library_exists(library.as_handle()) == Bool::True }
+    }
+
+    #[inline]
+    fn type_exists(&self, lib_type: &impl AsRef<str>) -> Result<bool, Error> {
+        let lib_str = lib_type.as_ref();
+        if lib_str.as_bytes().len() > LOADER_TYPE_MAX_LENGTH {
+            return Err(Error::InvalidLibraryType(String::from(lib_str)));
+        }
+
+        let lib_type = LibraryType::from(lib_str);
+
+        unsafe { Ok(self.type_exists(NonNullConst::from(&lib_type)) == Bool::True) }
+    }
+
+    #[inline]
+    fn get_library_types(&self, mut buffer: impl AsMut<[LibraryType]>) -> Result<usize, Error> {
+        unsafe {
+            self.get_library_types(NonNull::from(&MutSpan::from(buffer.as_mut())))
+                .to_result()
+                .map_err(Error::FFIError)
+        }
+    }
+
+    #[inline]
+    unsafe fn create_library_handle(&mut self) -> Library<'interface, Owned> {
+        Library::new(self.create_library_handle())
+    }
+
+    #[inline]
+    unsafe fn remove_library_handle(&mut self, library: Library<'_, Owned>) -> Result<(), Error> {
+        self.remove_library_handle(library.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn link_library<'library, 'loader, O, LO, IO>(
+        &mut self,
+        library: &Library<'library, O>,
+        loader: &Loader<'loader, LO>,
+        internal: &InternalLibrary<IO>,
+    ) -> Result<(), Error>
+    where
+        'loader: 'library,
+        O: MutableAccessIdentifier,
+        LO: ImmutableAccessIdentifier,
+        IO: ImmutableAccessIdentifier,
+    {
+        self.link_library(
+            library.as_handle(),
+            loader.as_handle(),
+            internal.as_handle(),
+        )
+        .to_result()
+        .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    fn get_internal_library_handle<'library, O>(
+        &self,
+        library: &Library<'library, O>,
+    ) -> Result<InternalLibrary<O>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_internal_library_handle(library.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(InternalLibrary::new(v)))
+        }
+    }
+
+    #[inline]
+    fn load<O>(
+        &mut self,
+        loader: &Loader<'interface, O>,
+        path: &impl AsRef<Path>,
+    ) -> Result<Library<'interface, Owned>, Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        let path_buff = path.as_ref().to_os_path_buff_null();
+        unsafe {
+            self.load(loader.as_handle(), NonNullConst::from(path_buff.as_slice()))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Library::new(v)))
+        }
+    }
+
+    #[inline]
+    fn unload(&mut self, library: Library<'_, Owned>) -> Result<(), Error> {
+        unsafe {
+            self.unload(library.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn get_data_symbol<'library, 'handle, O, U>(
+        &self,
+        library: &'handle Library<'library, O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(NonNullConst<c_void>) -> &'library U,
+    ) -> Result<Symbol<'handle, &'library U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_data_symbol(
+                library.as_handle(),
+                NonNullConst::from(symbol.as_ref().to_bytes_with_nul()),
+            )
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(Symbol::new(caster(v.symbol))),
+            )
+        }
+    }
+
+    #[inline]
+    fn get_function_symbol<'library, 'handle, O, U>(
+        &self,
+        library: &'handle Library<'library, O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(CBaseFn) -> U,
+    ) -> Result<Symbol<'handle, U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_function_symbol(
+                library.as_handle(),
+                NonNullConst::from(symbol.as_ref().to_bytes_with_nul()),
+            )
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(Symbol::new(caster(v.symbol))),
+            )
+        }
+    }
+}

--- a/emf-core-base-rs/src/library/library_loader.rs
+++ b/emf-core-base-rs/src/library/library_loader.rs
@@ -1,0 +1,805 @@
+//! API of a library loader.
+use crate::ffi::collections::NonNullConst;
+use crate::ffi::library::library_loader::{
+    LibraryLoaderBinding, LibraryLoaderInterface, NativeLibraryHandle, NativeLibraryLoaderInterface,
+};
+use crate::ffi::CBaseFn;
+use crate::library::{Error, InternalLibrary, Symbol};
+use crate::ownership::{
+    AccessIdentifier, ImmutableAccessIdentifier, MutableAccessIdentifier, Owned,
+};
+use crate::ToOsPathBuff;
+use std::borrow::Borrow;
+use std::ffi::{c_void, CStr};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+#[cfg(windows)]
+use std::os::windows::raw::HANDLE;
+use std::path::Path;
+#[cfg(windows)]
+use std::ptr::NonNull;
+
+/// Trait for identifying library loaders whose data structure is
+/// compatible with the canonical library loader.
+pub trait LibraryLoaderABICompat {}
+
+/// The API of a library loader.
+pub trait LibraryLoaderAPI<'a> {
+    /// Type of the internal loader.
+    type InternalLoader;
+
+    /// Fetches a pointer that can be used with the interface.
+    fn to_interface(&self) -> NonNullConst<LibraryLoaderInterface>;
+
+    /// Construct a new instance from a pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    unsafe fn from_interface(handler: NonNullConst<LibraryLoaderInterface>) -> Self;
+
+    /// Construct a new instance from a void pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    unsafe fn from_void_ptr(handler: NonNullConst<c_void>) -> Self;
+
+    /// Loads a library. The resulting handle is unique.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `loader` or `path` is invalid or
+    /// the type of the library can not be loaded with the loader.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoaderAPI] may break some invariants
+    /// of the library api, if not handled with care.
+    unsafe fn load(&mut self, path: &impl AsRef<Path>) -> Result<InternalLibrary<Owned>, Error>;
+
+    /// Unloads a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `internal` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoaderAPI] may break some invariants
+    /// of the library api, if not handled with care.
+    unsafe fn unload(&mut self, internal: InternalLibrary<Owned>) -> Result<(), Error>;
+
+    /// Fetches a data symbol from a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `internal` is invalid or library does not contain `symbol`.
+    ///
+    /// # Note
+    ///
+    /// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+    /// See [LibraryLoaderAPI::get_function_symbol()] for fetching a function.
+    ///
+    /// # Return
+    ///
+    /// Symbol on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoaderAPI] may break some invariants
+    /// of the library api, if not handled with care.
+    unsafe fn get_data_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(NonNullConst<c_void>) -> &'a U,
+    ) -> Result<Symbol<'a, &'a U>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches a function symbol from a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `internal` is invalid or library does not contain `symbol`.
+    ///
+    /// # Note
+    ///
+    /// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+    /// See [LibraryLoaderAPI::get_data_symbol()] for fetching some data.
+    ///
+    /// # Return
+    ///
+    /// Symbol on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoaderAPI] may break some invariants
+    /// of the library api, if not handled with care.
+    unsafe fn get_function_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(CBaseFn) -> U,
+    ) -> Result<Symbol<'a, U>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches a pointer to the internal interface.
+    ///
+    /// # Return
+    ///
+    /// Pointer to the interface.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoaderAPI] may break some invariants
+    /// of the library api, if not handled with care.
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader;
+}
+
+/// A library loader.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct LibraryLoader<T, O> {
+    _loader: T,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<'a, T, O> Deref for LibraryLoader<T, O>
+where
+    T: LibraryLoaderAPI<'a>,
+    O: AccessIdentifier,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self._loader
+    }
+}
+
+impl<'a, T, O> DerefMut for LibraryLoader<T, O>
+where
+    T: LibraryLoaderAPI<'a>,
+    O: MutableAccessIdentifier,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._loader
+    }
+}
+
+impl<'a, T, O> LibraryLoader<T, O>
+where
+    T: LibraryLoaderAPI<'a>,
+    O: AccessIdentifier,
+{
+    /// Fetches a pointer that can be used with the interface.
+    #[inline]
+    pub fn to_interface(&self) -> NonNullConst<LibraryLoaderInterface> {
+        self._loader.to_interface()
+    }
+
+    /// Construct a new instance from a pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    #[inline]
+    pub unsafe fn from_interface(handler: NonNullConst<LibraryLoaderInterface>) -> Self {
+        Self {
+            _loader: T::from_interface(handler),
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Construct a new instance from a void pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    #[inline]
+    pub unsafe fn from_void_ptr(handler: NonNullConst<c_void>) -> Self {
+        Self {
+            _loader: T::from_void_ptr(handler),
+            _ownership: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, O> LibraryLoader<T, O>
+where
+    T: LibraryLoaderAPI<'a>,
+    O: MutableAccessIdentifier,
+{
+    /// Loads a library. The resulting handle is unique.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `loader` or `path` is invalid or
+    /// the type of the library can not be loaded with the loader.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoader] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    pub unsafe fn load(
+        &mut self,
+        path: &impl AsRef<Path>,
+    ) -> Result<InternalLibrary<Owned>, Error> {
+        self._loader.load(path)
+    }
+
+    /// Unloads a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `internal` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoader] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    pub unsafe fn unload(&mut self, internal: InternalLibrary<Owned>) -> Result<(), Error> {
+        self._loader.unload(internal)
+    }
+}
+
+impl<'a, T, O> LibraryLoader<T, O>
+where
+    T: LibraryLoaderAPI<'a>,
+    O: ImmutableAccessIdentifier,
+{
+    /// Fetches a data symbol from a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `internal` is invalid or library does not contain `symbol`.
+    ///
+    /// # Note
+    ///
+    /// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+    /// See [LibraryLoader::get_function_symbol()] for fetching a function.
+    ///
+    /// # Return
+    ///
+    /// Symbol on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoader] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_data_symbol<LO, U>(
+        &self,
+        internal: &InternalLibrary<LO>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(NonNullConst<c_void>) -> &'a U,
+    ) -> Result<Symbol<'a, &'a U>, Error>
+    where
+        LO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_data_symbol(internal, symbol, caster)
+    }
+
+    /// Fetches a function symbol from a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `internal` is invalid or library does not contain `symbol`.
+    ///
+    /// # Note
+    ///
+    /// Some platforms may differentiate between a `function-pointer` and a `data-pointer`.
+    /// See [LibraryLoader::get_data_symbol()] for fetching some data.
+    ///
+    /// # Return
+    ///
+    /// Symbol on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoader] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_function_symbol<LO, U>(
+        &self,
+        internal: &InternalLibrary<LO>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(CBaseFn) -> U,
+    ) -> Result<Symbol<'a, U>, Error>
+    where
+        LO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_function_symbol(internal, symbol, caster)
+    }
+
+    /// Fetches a pointer to the internal interface.
+    ///
+    /// # Return
+    ///
+    /// Pointer to the interface.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [LibraryLoader] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_internal_interface(&self) -> LibraryLoader<T::InternalLoader, O> {
+        LibraryLoader {
+            _loader: self._loader.get_internal_interface(),
+            _ownership: PhantomData,
+        }
+    }
+}
+
+/// Invalid type erased library loader.
+#[derive(Debug, Copy, Clone)]
+pub struct InvalidLoader {
+    _interface: NonNullConst<c_void>,
+}
+
+unsafe impl Send for InvalidLoader {}
+unsafe impl Sync for InvalidLoader {}
+
+impl InvalidLoader {
+    /// Constructs a new instance.
+    #[inline]
+    pub fn new(interface: NonNullConst<c_void>) -> Self {
+        Self {
+            _interface: interface,
+        }
+    }
+}
+
+impl Deref for InvalidLoader {
+    type Target = NonNullConst<c_void>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self._interface
+    }
+}
+
+impl DerefMut for InvalidLoader {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._interface
+    }
+}
+
+/// Type erased library loader.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct UnknownLoader<'loader> {
+    _interface: NonNullConst<LibraryLoaderInterface>,
+    _phantom: PhantomData<&'loader ()>,
+}
+
+unsafe impl Send for UnknownLoader<'_> {}
+unsafe impl Sync for UnknownLoader<'_> {}
+
+impl Deref for UnknownLoader<'_> {
+    type Target = NonNullConst<LibraryLoaderInterface>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self._interface
+    }
+}
+
+impl DerefMut for UnknownLoader<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._interface
+    }
+}
+
+impl LibraryLoaderABICompat for UnknownLoader<'_> {}
+
+impl<'a> LibraryLoaderAPI<'a> for UnknownLoader<'a> {
+    type InternalLoader = InvalidLoader;
+
+    #[inline]
+    fn to_interface(&self) -> NonNullConst<LibraryLoaderInterface> {
+        self._interface
+    }
+
+    #[inline]
+    unsafe fn from_interface(interface: NonNullConst<LibraryLoaderInterface>) -> Self {
+        Self {
+            _interface: interface,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    unsafe fn from_void_ptr(interface: NonNullConst<c_void>) -> Self {
+        Self::from_interface(interface.cast())
+    }
+
+    #[inline]
+    unsafe fn load(&mut self, path: &impl AsRef<Path>) -> Result<InternalLibrary<Owned>, Error> {
+        let path_buff = path.as_ref().to_os_path_buff_null();
+        self._interface
+            .into_mut()
+            .as_mut()
+            .load(NonNullConst::from(path_buff.as_slice()))
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(InternalLibrary::new(v)))
+    }
+
+    #[inline]
+    unsafe fn unload(&mut self, internal: InternalLibrary<Owned>) -> Result<(), Error> {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .unload(internal.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn get_data_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(NonNullConst<c_void>) -> &'a U,
+    ) -> Result<Symbol<'a, &'a U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_data_symbol(
+                internal.borrow().as_handle(),
+                NonNullConst::from(symbol.as_ref().to_bytes_with_nul()),
+            )
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(Symbol::new(caster(v.symbol))),
+            )
+    }
+
+    #[inline]
+    unsafe fn get_function_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(CBaseFn) -> U,
+    ) -> Result<Symbol<'a, U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_function_symbol(
+                internal.borrow().as_handle(),
+                NonNullConst::from(symbol.as_ref().to_bytes_with_nul()),
+            )
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(Symbol::new(caster(v.symbol))),
+            )
+    }
+
+    #[inline]
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader {
+        Self::InternalLoader::new(self._interface.as_ref().get_internal_interface())
+    }
+}
+
+/// Native library loader.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct NativeLoader<'loader> {
+    _interface: UnknownLoader<'loader>,
+}
+
+impl Deref for NativeLoader<'_> {
+    type Target = NonNullConst<LibraryLoaderInterface>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self._interface.deref()
+    }
+}
+
+impl DerefMut for NativeLoader<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self._interface.deref_mut()
+    }
+}
+
+impl LibraryLoaderABICompat for NativeLoader<'_> {}
+
+impl<'a> LibraryLoaderAPI<'a> for NativeLoader<'a> {
+    type InternalLoader = NativeLoaderInternal<'a>;
+
+    #[inline]
+    fn to_interface(&self) -> NonNullConst<LibraryLoaderInterface> {
+        self._interface.to_interface()
+    }
+
+    #[inline]
+    unsafe fn from_interface(interface: NonNullConst<LibraryLoaderInterface>) -> Self {
+        Self {
+            _interface: UnknownLoader::from_interface(interface),
+        }
+    }
+
+    #[inline]
+    unsafe fn from_void_ptr(interface: NonNullConst<c_void>) -> Self {
+        Self::from_interface(interface.cast())
+    }
+
+    #[inline]
+    unsafe fn load(&mut self, path: &impl AsRef<Path>) -> Result<InternalLibrary<Owned>, Error> {
+        self._interface.load(path)
+    }
+
+    #[inline]
+    unsafe fn unload(&mut self, internal: InternalLibrary<Owned>) -> Result<(), Error> {
+        self._interface.unload(internal)
+    }
+
+    #[inline]
+    unsafe fn get_data_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(NonNullConst<c_void>) -> &'a U,
+    ) -> Result<Symbol<'a, &'a U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.get_data_symbol(internal, symbol, caster)
+    }
+
+    #[inline]
+    unsafe fn get_function_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(CBaseFn) -> U,
+    ) -> Result<Symbol<'a, U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .get_function_symbol(internal, symbol, caster)
+    }
+
+    #[inline]
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader {
+        Self::InternalLoader::from_void_ptr(*self._interface.get_internal_interface())
+    }
+}
+
+/// Native library loader internal interface.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct NativeLoaderInternal<'loader> {
+    _interface: NonNullConst<NativeLibraryLoaderInterface>,
+    _phantom: PhantomData<&'loader ()>,
+}
+
+unsafe impl Send for NativeLoaderInternal<'_> {}
+unsafe impl Sync for NativeLoaderInternal<'_> {}
+
+impl Deref for NativeLoaderInternal<'_> {
+    type Target = NonNullConst<NativeLibraryLoaderInterface>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self._interface
+    }
+}
+
+impl DerefMut for NativeLoaderInternal<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._interface
+    }
+}
+
+impl<'a> LibraryLoaderAPI<'a> for NativeLoaderInternal<'a> {
+    type InternalLoader = Self;
+
+    #[inline]
+    fn to_interface(&self) -> NonNullConst<LibraryLoaderInterface> {
+        unsafe { self._interface.as_ref().loader }
+    }
+
+    #[inline]
+    unsafe fn from_interface(interface: NonNullConst<LibraryLoaderInterface>) -> Self {
+        NativeLoader::from_interface(interface).get_internal_interface()
+    }
+
+    #[inline]
+    unsafe fn from_void_ptr(interface: NonNullConst<c_void>) -> Self {
+        Self {
+            _interface: interface.cast(),
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    unsafe fn load(&mut self, path: &impl AsRef<Path>) -> Result<InternalLibrary<Owned>, Error> {
+        NativeLoader::from_interface(self.to_interface()).load(path)
+    }
+
+    #[inline]
+    unsafe fn unload(&mut self, internal: InternalLibrary<Owned>) -> Result<(), Error> {
+        NativeLoader::from_interface(self.to_interface()).unload(internal)
+    }
+
+    #[inline]
+    unsafe fn get_data_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(NonNullConst<c_void>) -> &'a U,
+    ) -> Result<Symbol<'a, &'a U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).get_data_symbol(internal, symbol, caster)
+    }
+
+    #[inline]
+    unsafe fn get_function_symbol<O, U>(
+        &self,
+        internal: &InternalLibrary<O>,
+        symbol: &impl AsRef<CStr>,
+        caster: impl FnOnce(CBaseFn) -> U,
+    ) -> Result<Symbol<'a, U>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface())
+            .get_function_symbol(internal, symbol, caster)
+    }
+
+    #[inline]
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader {
+        *self
+    }
+}
+
+impl NativeLoaderInternal<'_> {
+    /// Loads a library. The resulting handle is unique.
+    ///
+    /// The argument `flags` is passed to `dlopen`.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `path` is invalid or
+    /// the call to `dlopen` fails.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeLoaderInternal] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    #[cfg(unix)]
+    pub unsafe fn load_ext(
+        &mut self,
+        path: &impl AsRef<Path>,
+        flags: i32,
+    ) -> Result<InternalLibrary<Owned>, Error> {
+        use crate::ffi::library::library_loader::NativeLibraryLoaderBindingUnix;
+
+        let path_buff = path.as_ref().to_os_path_buff_null();
+        self._interface
+            .into_mut()
+            .as_mut()
+            .load_ext(NonNullConst::from(path_buff.as_slice()), flags)
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(InternalLibrary::new(v)))
+    }
+
+    /// Loads a library. The resulting handle is unique.
+    ///
+    /// The arguments `h_file` and `flags` are passed to `LoadLibraryExW`.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `path` is invalid or
+    /// the call to `LoadLibraryExW` fails.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeLoaderInternal] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    #[cfg(windows)]
+    pub unsafe fn load_ext(
+        &mut self,
+        path: &impl AsRef<Path>,
+        h_file: Option<NonNull<HANDLE>>,
+        flags: u32,
+    ) -> Result<InternalLibrary<Owned>, Error> {
+        use crate::ffi::library::library_loader::NativeLibraryLoaderBindingWindows;
+
+        let path_buff = path.as_ref().to_os_path_buff_null();
+        self._interface
+            .into_mut()
+            .as_mut()
+            .load_ext(NonNullConst::from(path_buff.as_slice()), h_file, flags)
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(InternalLibrary::new(v)))
+    }
+
+    /// Returns the underlying handle of a library.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `internal` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeLoaderInternal] may break some invariants
+    /// of the library api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_native_handle<O>(
+        &self,
+        internal: &InternalLibrary<O>,
+    ) -> Result<NativeLibraryHandle, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        #[cfg(unix)]
+        use crate::ffi::library::library_loader::NativeLibraryLoaderBindingUnix;
+        #[cfg(windows)]
+        use crate::ffi::library::library_loader::NativeLibraryLoaderBindingWindows;
+
+        self._interface
+            .as_ref()
+            .get_native_handle(internal.borrow().as_handle())
+            .to_result()
+            .map_err(Error::FFIError)
+    }
+}

--- a/emf-core-base-rs/src/module.rs
+++ b/emf-core-base-rs/src/module.rs
@@ -1,0 +1,245 @@
+//! Module api
+//!
+//! # Example
+//!
+//! ```no_run
+//! # use emf_core_base_rs::{CBaseAccess, CBase};
+//! # let base_interface: &mut CBase = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+//! use emf_core_base_rs::CBaseAPI;
+//! use emf_core_base_rs::version::VersionAPI;
+//! use emf_core_base_rs::module::{
+//!     ModuleAPI, DEFAULT_HANDLE, InterfaceDescriptor, InterfaceName, Error, Module
+//! };
+//! use emf_core_base_rs::ffi::collections::ConstSpan;
+//! use std::path::Path;
+//!
+//! let result = CBaseAccess::lock(base_interface, |interface| -> Result<Module<'_, _>, Error> {
+//!     let module_path = Path::new("path to a module");
+//!     let interface_desc = InterfaceDescriptor {
+//!         name: InterfaceName::from("my_interface"),
+//!         version: VersionAPI::new_short(interface, 1, 0, 0),
+//!         extensions: ConstSpan::new()
+//!     };
+//!
+//!     let mut module = ModuleAPI::add_module(interface, &DEFAULT_HANDLE, &module_path)?;
+//!     ModuleAPI::load(interface, &mut module)?;
+//!     ModuleAPI::initialize(interface, &mut module)?;
+//!     ModuleAPI::export_interface(interface, &mut module, &interface_desc)?;
+//!     Ok(module)
+//! });
+//!
+//! assert_eq!(result.is_ok(), true);
+//! ```
+use crate::ffi::module::{InternalHandle, LoaderHandle, ModuleHandle};
+use crate::ownership::{AccessIdentifier, BorrowImmutable, BorrowMutable, Owned};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+
+mod api;
+pub mod module_loader;
+pub mod native_module;
+
+pub use crate::ffi::module::InterfaceDescriptor;
+pub use crate::ffi::module::InterfaceExtension;
+pub use crate::ffi::module::InterfaceName;
+pub use crate::ffi::module::ModuleInfo;
+pub use crate::ffi::module::ModuleName;
+pub use crate::ffi::module::ModuleStatus;
+pub use crate::ffi::module::ModuleType;
+pub use crate::ffi::module::ModuleVersion;
+pub use crate::ffi::module::INTERFACE_EXTENSION_NAME_MAX_LENGTH;
+pub use crate::ffi::module::INTERFACE_INFO_NAME_MAX_LENGTH;
+pub use crate::ffi::module::MODULE_INFO_NAME_MAX_LENGTH;
+pub use crate::ffi::module::MODULE_INFO_VERSION_MAX_LENGTH;
+pub use crate::ffi::module::MODULE_LOADER_TYPE_MAX_LENGTH;
+pub use crate::ffi::module::NATIVE_MODULE_INTERFACE_SYMBOL_NAME;
+pub use crate::ffi::module::NATIVE_MODULE_TYPE_NAME;
+
+pub use api::ModuleAPI;
+
+/// Handle of the default loader.
+pub const DEFAULT_HANDLE: Loader<'static, BorrowMutable<'static>> =
+    unsafe { Loader::new(crate::ffi::module::MODULE_LOADER_DEFAULT_HANDLE) };
+
+/// Errors of the module api.
+#[non_exhaustive]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub enum Error {
+    /// A Parameter error.
+    ParameterError(String),
+    /// Raw ffi module error.
+    FFIError(crate::ffi::module::Error),
+}
+
+/// A module handle.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Module<'a, O> {
+    _handle: ModuleHandle,
+    _lifetime: PhantomData<&'a ModuleHandle>,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<'a, O> Module<'a, O>
+where
+    O: AccessIdentifier,
+{
+    /// Construct a new instance from a handle.
+    ///
+    /// # Safety
+    ///
+    /// This function allows the creation of invalid handles
+    /// by bypassing lifetimes.
+    #[inline]
+    pub const unsafe fn new(handle: ModuleHandle) -> Self {
+        Self {
+            _handle: handle,
+            _lifetime: PhantomData,
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Fetches the internal handle.
+    #[inline]
+    pub const fn as_handle(&self) -> ModuleHandle {
+        self._handle
+    }
+}
+
+impl<'a> Module<'a, Owned> {
+    /// Borrows the library handle.
+    #[inline]
+    pub const fn as_borrowed(&self) -> Module<'a, BorrowImmutable<'_>> {
+        unsafe { Module::<BorrowImmutable<'_>>::new(self._handle) }
+    }
+
+    /// Borrows the library handle mutably.
+    #[inline]
+    pub fn as_borrowed_mut(&mut self) -> Module<'a, BorrowMutable<'_>> {
+        unsafe { Module::<BorrowMutable<'_>>::new(self._handle) }
+    }
+}
+
+/// A loader handle.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Loader<'a, O> {
+    _handle: LoaderHandle,
+    _lifetime: PhantomData<&'a LoaderHandle>,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<'a, O> Loader<'a, O>
+where
+    O: AccessIdentifier,
+{
+    /// Construct a new instance from a handle.
+    ///
+    /// # Safety
+    ///
+    /// This function allows the creation of invalid handles
+    /// by bypassing lifetimes.
+    #[inline]
+    pub const unsafe fn new(handle: LoaderHandle) -> Self {
+        Self {
+            _handle: handle,
+            _lifetime: PhantomData,
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Fetches the internal handle.
+    #[inline]
+    pub const fn as_handle(&self) -> LoaderHandle {
+        self._handle
+    }
+}
+
+impl<'a> Loader<'a, Owned> {
+    /// Borrows the loader handle.
+    #[inline]
+    pub const fn as_borrowed(&self) -> Loader<'a, BorrowImmutable<'_>> {
+        unsafe { Loader::<BorrowImmutable<'_>>::new(self._handle) }
+    }
+
+    /// Borrows the loader handle mutably.
+    #[inline]
+    pub fn as_borrowed_mut(&mut self) -> Loader<'a, BorrowMutable<'_>> {
+        unsafe { Loader::<BorrowMutable<'_>>::new(self._handle) }
+    }
+}
+
+/// A loader handle.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct InternalModule<O> {
+    _handle: InternalHandle,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<O> InternalModule<O>
+where
+    O: AccessIdentifier,
+{
+    /// Construct a new instance from a handle.
+    ///
+    /// # Safety
+    ///
+    /// This function allows the creation of invalid handles
+    /// by bypassing lifetimes.
+    #[inline]
+    pub const unsafe fn new(handle: InternalHandle) -> Self {
+        Self {
+            _handle: handle,
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Fetches the internal handle.
+    #[inline]
+    pub const fn as_handle(&self) -> InternalHandle {
+        self._handle
+    }
+}
+
+impl InternalModule<Owned> {
+    /// Borrows the loader handle.
+    #[inline]
+    pub const fn as_borrowed(&self) -> InternalModule<BorrowImmutable<'_>> {
+        unsafe { InternalModule::<BorrowImmutable<'_>>::new(self._handle) }
+    }
+
+    /// Borrows the loader handle mutably.
+    #[inline]
+    pub fn as_borrowed_mut(&mut self) -> InternalModule<BorrowMutable<'_>> {
+        unsafe { InternalModule::<BorrowMutable<'_>>::new(self._handle) }
+    }
+}
+
+/// Interface from a module.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Interface<'a, T> {
+    _interface: T,
+    _phantom: PhantomData<&'a ()>,
+}
+
+impl<T> Interface<'_, T> {
+    #[inline]
+    fn new(interface: T) -> Self {
+        Self {
+            _interface: interface,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Deref for Interface<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self._interface
+    }
+}
+
+impl<T> DerefMut for Interface<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._interface
+    }
+}

--- a/emf-core-base-rs/src/module/api.rs
+++ b/emf-core-base-rs/src/module/api.rs
@@ -1,0 +1,1006 @@
+use crate::ffi::collections::{MutSpan, NonNullConst};
+use crate::ffi::library::OSPathChar;
+use crate::ffi::module::api::ModuleBinding;
+use crate::ffi::Bool;
+use crate::module::module_loader::{ModuleLoader, ModuleLoaderABICompat, ModuleLoaderAPI};
+use crate::module::{
+    Error, Interface, InterfaceDescriptor, InternalModule, Loader, Module, ModuleInfo,
+    ModuleStatus, ModuleType, MODULE_LOADER_TYPE_MAX_LENGTH,
+};
+use crate::ownership::{
+    BorrowImmutable, BorrowMutable, ImmutableAccessIdentifier, MutableAccessIdentifier, Owned,
+};
+use crate::ToOsPathBuff;
+use std::path::Path;
+use std::ptr::NonNull;
+
+/// Idiomatic module api.
+pub trait ModuleAPI<'interface> {
+    /// Registers a new module loader.
+    ///
+    /// Module types starting with `__` are reserved for future use.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `mod_type` already exists.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn register_loader<'loader, LT, L>(
+        &mut self,
+        loader: &'loader LT,
+        mod_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, Owned>, Error>
+    where
+        L: ModuleLoaderAPI<'static>,
+        ModuleLoader<L, Owned>: From<&'loader LT>;
+
+    /// Unregisters an existing module loader.
+    ///
+    /// Unregistering a module loader also unloads the modules it loaded.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `loader` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn unregister_loader(&mut self, loader: Loader<'_, Owned>) -> Result<(), Error>;
+
+    /// Fetches the interface of a module loader.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `loader` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Interface on success, error otherwise.
+    fn get_loader_interface<'loader, O, L>(
+        &mut self,
+        loader: &Loader<'loader, O>,
+    ) -> Result<ModuleLoader<L, O>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+        L: ModuleLoaderAPI<'loader> + ModuleLoaderABICompat;
+
+    /// Fetches the handle of the loader associated with a module type.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `mod_type` does not exist.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn get_loader_handle_from_type(
+        &self,
+        mod_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, BorrowMutable<'_>>, Error>;
+
+    /// Fetches the handle of the loader linked with the module handle.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `module` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    fn get_loader_handle_from_module<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<Loader<'module, BorrowMutable<'_>>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the number of loaded modules.
+    ///
+    /// # Return
+    ///
+    /// Number of modules.
+    fn get_num_modules(&self) -> usize;
+
+    /// Fetches the number of loaders.
+    ///
+    /// # Return
+    ///
+    /// Number of module loaders.
+    fn get_num_loaders(&self) -> usize;
+
+    /// Fetches the number of exported interfaces.
+    ///
+    /// # Return
+    ///
+    /// Number of exported interfaces.
+    fn get_num_exported_interfaces(&self) -> usize;
+
+    /// Checks if a module exists.
+    ///
+    /// # Return
+    ///
+    /// [true] if it exists, [false] otherwise.
+    fn module_exists<'module, O>(&self, module: &Module<'module, O>) -> bool
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Checks if a module type exists.
+    ///
+    /// # Return
+    ///
+    /// [true] if it exists, [false] otherwise.
+    fn type_exists(&self, mod_type: &impl AsRef<str>) -> Result<bool, Error>;
+
+    /// Checks whether an exported interface exists.
+    ///
+    /// # Return
+    ///
+    /// [true] if it exists, [false] otherwise.
+    fn exported_interface_exists(&self, interface: &InterfaceDescriptor) -> bool;
+
+    /// Copies the available module info into a buffer.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `buffer.as_ref().len() < get_num_modules()`.
+    ///
+    /// # Return
+    ///
+    /// Number if written module info on success, error otherwise.
+    fn get_modules(&self, buffer: &mut impl AsMut<[ModuleInfo]>) -> Result<usize, Error>;
+
+    /// Copies the available module types into a buffer.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `buffer.as_ref().len() < get_num_loaders()`.
+    ///
+    /// # Return
+    ///
+    /// Number if written module types on success, error otherwise.
+    fn get_module_types(&self, buffer: &mut impl AsMut<[ModuleType]>) -> Result<usize, Error>;
+
+    /// Copies the descriptors of the exported interfaces into a buffer.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `buffer.as_ref().len() < get_num_exported_interfaces()`.
+    ///
+    /// # Return
+    ///
+    /// Number if written descriptors on success, error otherwise.
+    fn get_exported_interfaces(
+        &self,
+        buffer: &mut impl AsMut<[InterfaceDescriptor]>,
+    ) -> Result<usize, Error>;
+
+    /// Fetches the module handle of the exported interface.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `interface` does not exist.
+    ///
+    /// # Return
+    ///
+    /// Module handle on success, error otherwise.
+    fn get_exported_interface_handle(
+        &self,
+        interface: &InterfaceDescriptor,
+    ) -> Result<Module<'interface, BorrowImmutable<'_>>, Error>;
+
+    /// Creates a new unlinked module handle.
+    ///
+    /// # Return
+    ///
+    /// Module handle.
+    ///
+    /// # Safety
+    ///
+    /// The handle remains invalid until it's linked with [ModuleAPI::link_module].
+    unsafe fn create_module_handle(&mut self) -> Module<'interface, Owned>;
+
+    /// Links a module handle to an internal module handle.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` or`loader` are invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// Removing the handle does not unload the module.
+    unsafe fn remove_module_handle(&mut self, module: Module<'_, Owned>) -> Result<(), Error>;
+
+    /// Links a module handle to an internal module handle.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` or`loader` are invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// Incorrect usage can lead to dangling handles or use-after-free errors.
+    unsafe fn link_module<'module, 'loader, O, LO, IO>(
+        &mut self,
+        module: &Module<'module, O>,
+        loader: &Loader<'loader, LO>,
+        internal: &InternalModule<IO>,
+    ) -> Result<(), Error>
+    where
+        'loader: 'module,
+        O: MutableAccessIdentifier,
+        LO: ImmutableAccessIdentifier,
+        IO: ImmutableAccessIdentifier;
+
+    /// Fetches the internal handle linked with the module handle.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Internal handle on success, error otherwise.
+    fn get_internal_module_handle<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<InternalModule<O>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Adds a new module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `loader` or `path` is invalid or the type
+    /// of the module can not be loaded with the loader.
+    ///
+    /// # Return
+    ///
+    /// Module handle on success, error otherwise.
+    fn add_module<O>(
+        &mut self,
+        loader: &Loader<'interface, O>,
+        path: &impl AsRef<Path>,
+    ) -> Result<Module<'interface, Owned>, Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Removes a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid or the module is not in an unloaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn remove_module(&mut self, module: Module<'_, Owned>) -> Result<(), Error>;
+
+    /// Loads a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid, the load dependencies of the module are
+    /// not exported or the module is not in an unloaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn load<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Unloads a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid or the module is in an unloaded or ready state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn unload<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Initializes a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid, the runtime dependencies of the
+    /// module are not exported or the module is not in a loaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn initialize<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Terminates a module.
+    ///
+    /// Terminating a module also removes the interfaces it exported.
+    /// The modules that depend on the module are terminated.
+    /// If they list the module as a load dependency, they are also unloaded.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid or the module is not in a ready state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn terminate<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Registers a new runtime dependency of the module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn add_dependency<O>(
+        &mut self,
+        module: &mut Module<'_, O>,
+        interface: &InterfaceDescriptor,
+    ) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Removes an existing runtime dependency from the module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn remove_dependency<O>(
+        &mut self,
+        module: &mut Module<'_, O>,
+        interface: &InterfaceDescriptor,
+    ) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Exports an interface of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid, `interface` is already exported,
+    /// `interface` is not contained in the module or the module is not yet initialized.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    fn export_interface<O>(
+        &mut self,
+        module: &Module<'_, O>,
+        interface: &InterfaceDescriptor,
+    ) -> Result<(), Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the load dependencies of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Load dependencies on success, error otherwise.
+    fn get_load_dependencies<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the runtime dependencies of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Runtime dependencies on success, error otherwise.
+    fn get_runtime_dependencies<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the exportable interfaces of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Exportable interfaces on success, error otherwise.
+    fn get_exportable_interfaces<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the load status of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Module status on success, error otherwise.
+    fn fetch_status<O>(&self, module: &Module<'_, O>) -> Result<ModuleStatus, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the path a module was loaded from.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Module path on success, error otherwise.
+    fn get_module_path<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [OSPathChar], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the module info from a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Module info on success, error otherwise.
+    fn get_module_info<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module ModuleInfo, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches an interface from a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `module` is invalid, the module is not in a ready
+    /// state or the interface is not contained in the module.
+    ///
+    /// # Return
+    ///
+    /// Interface on success, error otherwise.
+    fn get_interface<'module, O, T>(
+        &self,
+        module: &'module Module<'_, O>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> T,
+    ) -> Result<Interface<'module, T>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+}
+
+impl<'interface, T> ModuleAPI<'interface> for T
+where
+    T: ModuleBinding,
+{
+    #[inline]
+    fn register_loader<'loader, LT, L>(
+        &mut self,
+        loader: &'loader LT,
+        mod_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, Owned>, Error>
+    where
+        L: ModuleLoaderAPI<'static>,
+        ModuleLoader<L, Owned>: From<&'loader LT>,
+    {
+        let mod_str = mod_type.as_ref();
+        if mod_str.as_bytes().len() > MODULE_LOADER_TYPE_MAX_LENGTH {
+            return Err(Error::ParameterError(format!(
+                "Invalid module type: {}",
+                mod_str
+            )));
+        }
+
+        let mod_type = ModuleType::from(mod_str);
+
+        unsafe {
+            self.register_loader(
+                ModuleLoader::<L, Owned>::from(loader).to_interface(),
+                NonNullConst::from(&mod_type),
+            )
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Loader::new(v)))
+        }
+    }
+
+    #[inline]
+    fn unregister_loader(&mut self, loader: Loader<'_, Owned>) -> Result<(), Error> {
+        unsafe {
+            self.unregister_loader(loader.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn get_loader_interface<'loader, O, L>(
+        &mut self,
+        loader: &Loader<'loader, O>,
+    ) -> Result<ModuleLoader<L, O>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+        L: ModuleLoaderAPI<'loader> + ModuleLoaderABICompat,
+    {
+        unsafe {
+            self.get_loader_interface(loader.as_handle())
+                .to_result()
+                .map_or_else(
+                    |e| Err(Error::FFIError(e)),
+                    |v| Ok(ModuleLoader::from_interface(v)),
+                )
+        }
+    }
+
+    #[inline]
+    fn get_loader_handle_from_type(
+        &self,
+        mod_type: &impl AsRef<str>,
+    ) -> Result<Loader<'interface, BorrowMutable<'_>>, Error> {
+        let mod_str = mod_type.as_ref();
+        if mod_str.as_bytes().len() > MODULE_LOADER_TYPE_MAX_LENGTH {
+            return Err(Error::ParameterError(format!(
+                "Invalid module type: {}",
+                mod_str
+            )));
+        }
+
+        let mod_type = ModuleType::from(mod_str);
+
+        unsafe {
+            self.get_loader_handle_from_type(NonNullConst::from(&mod_type))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Loader::new(v)))
+        }
+    }
+
+    #[inline]
+    fn get_loader_handle_from_module<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<Loader<'module, BorrowMutable<'_>>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_loader_handle_from_module(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Loader::new(v)))
+        }
+    }
+
+    #[inline]
+    fn get_num_modules(&self) -> usize {
+        unsafe { self.get_num_modules() }
+    }
+
+    #[inline]
+    fn get_num_loaders(&self) -> usize {
+        unsafe { self.get_num_loaders() }
+    }
+
+    #[inline]
+    fn get_num_exported_interfaces(&self) -> usize {
+        unsafe { self.get_num_exported_interfaces() }
+    }
+
+    #[inline]
+    fn module_exists<'module, O>(&self, module: &Module<'module, O>) -> bool
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe { self.module_exists(module.as_handle()) == Bool::True }
+    }
+
+    #[inline]
+    fn type_exists(&self, mod_type: &impl AsRef<str>) -> Result<bool, Error> {
+        let mod_str = mod_type.as_ref();
+        if mod_str.as_bytes().len() > MODULE_LOADER_TYPE_MAX_LENGTH {
+            return Err(Error::ParameterError(format!(
+                "Invalid module type: {}",
+                mod_str
+            )));
+        }
+
+        let mod_type = ModuleType::from(mod_str);
+
+        unsafe { Ok(self.type_exists(NonNullConst::from(&mod_type)) == Bool::True) }
+    }
+
+    #[inline]
+    fn exported_interface_exists(&self, interface: &InterfaceDescriptor) -> bool {
+        unsafe { self.exported_interface_exists(NonNullConst::from(interface)) == Bool::True }
+    }
+
+    #[inline]
+    fn get_modules(&self, buffer: &mut impl AsMut<[ModuleInfo]>) -> Result<usize, Error> {
+        unsafe {
+            self.get_modules(NonNull::from(&MutSpan::from(buffer.as_mut())))
+                .to_result()
+                .map_err(Error::FFIError)
+        }
+    }
+
+    #[inline]
+    fn get_module_types(&self, buffer: &mut impl AsMut<[ModuleType]>) -> Result<usize, Error> {
+        unsafe {
+            self.get_module_types(NonNull::from(&MutSpan::from(buffer.as_mut())))
+                .to_result()
+                .map_err(Error::FFIError)
+        }
+    }
+
+    #[inline]
+    fn get_exported_interfaces(
+        &self,
+        buffer: &mut impl AsMut<[InterfaceDescriptor]>,
+    ) -> Result<usize, Error> {
+        unsafe {
+            self.get_exported_interfaces(NonNull::from(&MutSpan::from(buffer.as_mut())))
+                .to_result()
+                .map_err(Error::FFIError)
+        }
+    }
+
+    #[inline]
+    fn get_exported_interface_handle(
+        &self,
+        interface: &InterfaceDescriptor,
+    ) -> Result<Module<'interface, BorrowImmutable<'_>>, Error> {
+        unsafe {
+            self.get_exported_interface_handle(NonNullConst::from(interface))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Module::new(v)))
+        }
+    }
+
+    #[inline]
+    unsafe fn create_module_handle(&mut self) -> Module<'interface, Owned> {
+        Module::new(self.create_module_handle())
+    }
+
+    #[inline]
+    unsafe fn remove_module_handle(&mut self, module: Module<'_, Owned>) -> Result<(), Error> {
+        self.remove_module_handle(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn link_module<'module, 'loader, O, LO, IO>(
+        &mut self,
+        module: &Module<'module, O>,
+        loader: &Loader<'loader, LO>,
+        internal: &InternalModule<IO>,
+    ) -> Result<(), Error>
+    where
+        'loader: 'module,
+        O: MutableAccessIdentifier,
+        LO: ImmutableAccessIdentifier,
+        IO: ImmutableAccessIdentifier,
+    {
+        self.link_module(module.as_handle(), loader.as_handle(), internal.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    fn get_internal_module_handle<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<InternalModule<O>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_internal_module_handle(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(InternalModule::new(v)))
+        }
+    }
+
+    #[inline]
+    fn add_module<O>(
+        &mut self,
+        loader: &Loader<'interface, O>,
+        path: &impl AsRef<Path>,
+    ) -> Result<Module<'interface, Owned>, Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        let path_buff = path.as_ref().to_os_path_buff_null();
+        unsafe {
+            self.add_module(loader.as_handle(), NonNullConst::from(path_buff.as_slice()))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(Module::new(v)))
+        }
+    }
+
+    #[inline]
+    fn remove_module(&mut self, module: Module<'_, Owned>) -> Result<(), Error> {
+        unsafe {
+            self.remove_module(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn load<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        unsafe {
+            self.load(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn unload<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        unsafe {
+            self.unload(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn initialize<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        unsafe {
+            self.initialize(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn terminate<O>(&mut self, module: &mut Module<'_, O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        unsafe {
+            self.terminate(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn add_dependency<O>(
+        &mut self,
+        module: &mut Module<'_, O>,
+        interface: &InterfaceDescriptor,
+    ) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        unsafe {
+            self.add_dependency(module.as_handle(), NonNullConst::from(interface))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn remove_dependency<O>(
+        &mut self,
+        module: &mut Module<'_, O>,
+        interface: &InterfaceDescriptor,
+    ) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        unsafe {
+            self.remove_dependency(module.as_handle(), NonNullConst::from(interface))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn export_interface<O>(
+        &mut self,
+        module: &Module<'_, O>,
+        interface: &InterfaceDescriptor,
+    ) -> Result<(), Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.export_interface(module.as_handle(), NonNullConst::from(interface))
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+        }
+    }
+
+    #[inline]
+    fn get_load_dependencies<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_load_dependencies(module.as_handle())
+                .to_result()
+                .map_or_else(
+                    |e| Err(Error::FFIError(e)),
+                    |v| {
+                        if v.is_empty() {
+                            Ok(<&[_]>::default())
+                        } else {
+                            Ok(std::slice::from_raw_parts(v.as_ptr(), v.len()))
+                        }
+                    },
+                )
+        }
+    }
+
+    #[inline]
+    fn get_runtime_dependencies<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_runtime_dependencies(module.as_handle())
+                .to_result()
+                .map_or_else(
+                    |e| Err(Error::FFIError(e)),
+                    |v| {
+                        if v.is_empty() {
+                            Ok(<&[_]>::default())
+                        } else {
+                            Ok(std::slice::from_raw_parts(v.as_ptr(), v.len()))
+                        }
+                    },
+                )
+        }
+    }
+
+    #[inline]
+    fn get_exportable_interfaces<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_exportable_interfaces(module.as_handle())
+                .to_result()
+                .map_or_else(
+                    |e| Err(Error::FFIError(e)),
+                    |v| {
+                        if v.is_empty() {
+                            Ok(<&[_]>::default())
+                        } else {
+                            Ok(std::slice::from_raw_parts(v.as_ptr(), v.len()))
+                        }
+                    },
+                )
+        }
+    }
+
+    #[inline]
+    fn fetch_status<O>(&self, module: &Module<'_, O>) -> Result<ModuleStatus, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.fetch_status(module.as_handle())
+                .to_result()
+                .map_err(Error::FFIError)
+        }
+    }
+
+    #[inline]
+    fn get_module_path<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module [OSPathChar], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_module_path(module.as_handle())
+                .to_result()
+                .map_or_else(
+                    |e| Err(Error::FFIError(e)),
+                    |v| {
+                        let mut end = v.as_ptr();
+                        while *end != 0 {
+                            end = end.offset(1);
+                        }
+                        let length = 1 + end.offset_from(v.as_ptr()) as usize;
+                        Ok(std::slice::from_raw_parts(v.as_ptr(), length))
+                    },
+                )
+        }
+    }
+
+    #[inline]
+    fn get_module_info<'module, O>(
+        &self,
+        module: &Module<'module, O>,
+    ) -> Result<&'module ModuleInfo, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_module_info(module.as_handle())
+                .to_result()
+                .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(&*v.as_ptr()))
+        }
+    }
+
+    #[inline]
+    fn get_interface<'module, O, IT>(
+        &self,
+        module: &'module Module<'_, O>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> IT,
+    ) -> Result<Interface<'module, IT>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        unsafe {
+            self.get_interface(module.as_handle(), NonNullConst::from(interface))
+                .to_result()
+                .map_or_else(
+                    |e| Err(Error::FFIError(e)),
+                    |v| Ok(Interface::new(caster(v))),
+                )
+        }
+    }
+}

--- a/emf-core-base-rs/src/module/module_loader.rs
+++ b/emf-core-base-rs/src/module/module_loader.rs
@@ -1,0 +1,1437 @@
+//! API of a module loader.
+use crate::ffi::collections::NonNullConst;
+use crate::ffi::library::OSPathChar;
+use crate::ffi::module::module_loader::{
+    ModuleLoaderBinding, ModuleLoaderInterface, NativeModuleLoaderBinding,
+    NativeModuleLoaderInterface,
+};
+use crate::module::native_module::NativeModuleInstance;
+use crate::module::{
+    Error, Interface, InterfaceDescriptor, InternalModule, ModuleInfo, ModuleStatus,
+};
+use crate::ownership::{
+    AccessIdentifier, ImmutableAccessIdentifier, MutableAccessIdentifier, Owned,
+};
+use crate::ToOsPathBuff;
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::path::Path;
+
+/// Trait for identifying module loaders whose data layout is
+/// compatible with the canonical module loader.
+pub trait ModuleLoaderABICompat {}
+
+/// The API of a module loader.
+pub trait ModuleLoaderAPI<'a> {
+    /// Type of the internal loader.
+    type InternalLoader;
+
+    /// Fetches a pointer that can be used with the interface.
+    fn to_interface(&self) -> NonNullConst<ModuleLoaderInterface>;
+
+    /// Construct a new instance from a pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    unsafe fn from_interface(handler: NonNullConst<ModuleLoaderInterface>) -> Self;
+
+    /// Construct a new instance from a void pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    unsafe fn from_void_ptr(handler: NonNullConst<c_void>) -> Self;
+
+    /// Adds a new module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `path` is invalid or the type of the
+    /// module can not be loaded with the loader.
+    ///
+    /// # Return
+    ///
+    /// Module handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn add_module(
+        &mut self,
+        path: &impl AsRef<Path>,
+    ) -> Result<InternalModule<Owned>, Error>;
+
+    /// Removes a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not in an unloaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn remove_module(&mut self, module: InternalModule<Owned>) -> Result<(), Error>;
+
+    /// Loads a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid, the load dependencies of the module are
+    /// not exported or the module is not in an unloaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn load<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Unloads a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is in an unloaded or ready state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn unload<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Initializes a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid, the runtime dependencies of the
+    /// module are not exported or the module is not in a loaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn initialize<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Terminates a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not in a ready state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn terminate<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier;
+
+    /// Fetches the load status of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Module status on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn fetch_status<O>(&self, module: &InternalModule<O>) -> Result<ModuleStatus, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches an interface from a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid, the module is not in a ready
+    /// state or the interface is not contained in the module.
+    ///
+    /// # Return
+    ///
+    /// Interface on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn get_interface<'module, O, T>(
+        &self,
+        module: &'module InternalModule<O>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> T,
+    ) -> Result<Interface<'module, T>, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the module info from a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Module info on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn get_module_info<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module ModuleInfo, Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the path a module was loaded from.
+    ///
+    /// The resulting slice is terminated with a `\0` character.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Module path on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn get_module_path<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [OSPathChar], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the load dependencies of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Load dependencies on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn get_load_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the runtime dependencies of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Runtime dependencies on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn get_runtime_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches the exportable interfaces of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Exportable interfaces on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn get_exportable_interfaces<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier;
+
+    /// Fetches a pointer to the internal loader interface.
+    ///
+    /// # Return
+    ///
+    /// Pointer to the loader interface.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoaderAPI] may break some invariants
+    /// of the module api, if not handled with care.
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader;
+}
+
+/// A module loader.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct ModuleLoader<T, O> {
+    _loader: T,
+    _ownership: PhantomData<*const O>,
+}
+
+impl<'a, T, O> Deref for ModuleLoader<T, O>
+where
+    T: ModuleLoaderAPI<'a>,
+    O: AccessIdentifier,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self._loader
+    }
+}
+
+impl<'a, T, O> DerefMut for ModuleLoader<T, O>
+where
+    T: ModuleLoaderAPI<'a>,
+    O: MutableAccessIdentifier,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._loader
+    }
+}
+
+impl<'a, T, O> ModuleLoader<T, O>
+where
+    T: ModuleLoaderAPI<'a>,
+    O: AccessIdentifier,
+{
+    /// Fetches a pointer that can be used with the interface.
+    #[inline]
+    pub fn to_interface(&self) -> NonNullConst<ModuleLoaderInterface> {
+        self._loader.to_interface()
+    }
+
+    /// Construct a new instance from a pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    #[inline]
+    pub unsafe fn from_interface(loader: NonNullConst<ModuleLoaderInterface>) -> Self {
+        Self {
+            _loader: T::from_interface(loader),
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Construct a new instance from a void pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    #[inline]
+    pub unsafe fn from_void_ptr(handler: NonNullConst<c_void>) -> Self {
+        Self {
+            _loader: T::from_void_ptr(handler),
+            _ownership: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, O> ModuleLoader<T, O>
+where
+    T: ModuleLoaderAPI<'a>,
+    O: MutableAccessIdentifier,
+{
+    /// Adds a new module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `path` is invalid or the type of the
+    /// module can not be loaded with the loader.
+    ///
+    /// # Return
+    ///
+    /// Module handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn add_module(
+        &mut self,
+        path: &impl AsRef<Path>,
+    ) -> Result<InternalModule<Owned>, Error> {
+        self._loader.add_module(path)
+    }
+
+    /// Removes a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not in an unloaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn remove_module(&mut self, module: InternalModule<Owned>) -> Result<(), Error> {
+        self._loader.remove_module(module)
+    }
+
+    /// Loads a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid, the load dependencies of the module are
+    /// not exported or the module is not in an unloaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn load<MO>(&mut self, module: &mut InternalModule<MO>) -> Result<(), Error>
+    where
+        MO: MutableAccessIdentifier,
+    {
+        self._loader.load(module)
+    }
+
+    /// Unloads a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is in an unloaded or ready state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn unload<MO>(&mut self, module: &mut InternalModule<MO>) -> Result<(), Error>
+    where
+        MO: MutableAccessIdentifier,
+    {
+        self._loader.unload(module)
+    }
+
+    /// Initializes a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid, the runtime dependencies of the
+    /// module are not exported or the module is not in a loaded state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn initialize<MO>(&mut self, module: &mut InternalModule<MO>) -> Result<(), Error>
+    where
+        MO: MutableAccessIdentifier,
+    {
+        self._loader.initialize(module)
+    }
+
+    /// Terminates a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not in a ready state.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn terminate<MO>(&mut self, module: &mut InternalModule<MO>) -> Result<(), Error>
+    where
+        MO: MutableAccessIdentifier,
+    {
+        self._loader.terminate(module)
+    }
+}
+
+impl<'a, T, O> ModuleLoader<T, O>
+where
+    T: ModuleLoaderAPI<'a>,
+    O: ImmutableAccessIdentifier,
+{
+    /// Fetches the load status of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Module status on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn fetch_status<MO>(
+        &self,
+        module: &InternalModule<MO>,
+    ) -> Result<ModuleStatus, Error>
+    where
+        MO: ImmutableAccessIdentifier,
+    {
+        self._loader.fetch_status(module)
+    }
+
+    /// Fetches an interface from a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid, the module is not in a ready
+    /// state or the interface is not contained in the module.
+    ///
+    /// # Return
+    ///
+    /// Interface on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_interface<'module, MO, IT>(
+        &self,
+        module: &'module InternalModule<MO>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> IT,
+    ) -> Result<Interface<'module, IT>, Error>
+    where
+        MO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_interface(module, interface, caster)
+    }
+
+    /// Fetches the module info from a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Module info on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_module_info<'module, MO>(
+        &self,
+        module: &'module InternalModule<MO>,
+    ) -> Result<&'module ModuleInfo, Error>
+    where
+        MO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_module_info(module)
+    }
+
+    /// Fetches the path a module was loaded from.
+    ///
+    /// The resulting slice is terminated with a `\0` character.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Module path on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_module_path<'module, MO>(
+        &self,
+        module: &'module InternalModule<MO>,
+    ) -> Result<&'module [OSPathChar], Error>
+    where
+        MO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_module_path(module)
+    }
+
+    /// Fetches the load dependencies of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Load dependencies on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_load_dependencies<'module, MO>(
+        &self,
+        module: &'module InternalModule<MO>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        MO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_load_dependencies(module)
+    }
+
+    /// Fetches the runtime dependencies of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Runtime dependencies on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_runtime_dependencies<'module, MO>(
+        &self,
+        module: &'module InternalModule<MO>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        MO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_runtime_dependencies(module)
+    }
+
+    /// Fetches the exportable interfaces of a module.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `handle` is invalid or the module is not yet loaded.
+    ///
+    /// # Return
+    ///
+    /// Exportable interfaces on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_exportable_interfaces<'module, MO>(
+        &self,
+        module: &'module InternalModule<MO>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        MO: ImmutableAccessIdentifier,
+    {
+        self._loader.get_exportable_interfaces(module)
+    }
+
+    /// Fetches a pointer to the internal loader interface.
+    ///
+    /// # Return
+    ///
+    /// Pointer to the loader interface.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [ModuleLoader] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_internal_interface(&self) -> ModuleLoader<T::InternalLoader, O> {
+        ModuleLoader {
+            _loader: self._loader.get_internal_interface(),
+            _ownership: PhantomData,
+        }
+    }
+}
+
+/// Invalid type erased module loader.
+#[derive(Debug, Copy, Clone)]
+pub struct InvalidLoader {
+    _interface: NonNullConst<c_void>,
+}
+
+unsafe impl Send for InvalidLoader {}
+unsafe impl Sync for InvalidLoader {}
+
+impl InvalidLoader {
+    /// Constructs a new instance.
+    #[inline]
+    pub fn new(interface: NonNullConst<c_void>) -> Self {
+        Self {
+            _interface: interface,
+        }
+    }
+}
+
+impl Deref for InvalidLoader {
+    type Target = NonNullConst<c_void>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self._interface
+    }
+}
+
+impl DerefMut for InvalidLoader {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._interface
+    }
+}
+
+/// Type erased module loader.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct UnknownLoader<'loader> {
+    _interface: NonNullConst<ModuleLoaderInterface>,
+    _phantom: PhantomData<&'loader ()>,
+}
+
+unsafe impl Send for UnknownLoader<'_> {}
+unsafe impl Sync for UnknownLoader<'_> {}
+
+impl Deref for UnknownLoader<'_> {
+    type Target = NonNullConst<ModuleLoaderInterface>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self._interface
+    }
+}
+
+impl DerefMut for UnknownLoader<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._interface
+    }
+}
+
+impl ModuleLoaderABICompat for UnknownLoader<'_> {}
+
+impl<'a> ModuleLoaderAPI<'a> for UnknownLoader<'a> {
+    type InternalLoader = InvalidLoader;
+
+    #[inline]
+    fn to_interface(&self) -> NonNullConst<ModuleLoaderInterface> {
+        self._interface
+    }
+
+    #[inline]
+    unsafe fn from_interface(interface: NonNullConst<ModuleLoaderInterface>) -> Self {
+        Self {
+            _interface: interface,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    unsafe fn from_void_ptr(interface: NonNullConst<c_void>) -> Self {
+        // Safety: Assumes that the pointer is of the type `*const ModuleLoaderInterface`.
+        Self::from_interface(interface.cast())
+    }
+
+    #[inline]
+    unsafe fn add_module(
+        &mut self,
+        path: &impl AsRef<Path>,
+    ) -> Result<InternalModule<Owned>, Error> {
+        let path_buff = path.as_ref().to_os_path_buff_null();
+        self._interface
+            .into_mut()
+            .as_mut()
+            .add_module(NonNullConst::from(path_buff.as_slice()))
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(InternalModule::new(v)))
+    }
+
+    #[inline]
+    unsafe fn remove_module(&mut self, module: InternalModule<Owned>) -> Result<(), Error> {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .remove_module(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn load<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .load(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn unload<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .unload(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn initialize<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .initialize(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn terminate<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .terminate(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    #[inline]
+    unsafe fn fetch_status<O>(&self, module: &InternalModule<O>) -> Result<ModuleStatus, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .fetch_status(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), Ok)
+    }
+
+    #[inline]
+    unsafe fn get_interface<'module, O, T>(
+        &self,
+        module: &'module InternalModule<O>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> T,
+    ) -> Result<Interface<'module, T>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_interface(module.as_handle(), NonNullConst::from(interface))
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(Interface::new(caster(v))),
+            )
+    }
+
+    #[inline]
+    unsafe fn get_module_info<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module ModuleInfo, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_module_info(module.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(&*v.as_ptr()))
+    }
+
+    #[inline]
+    unsafe fn get_module_path<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [OSPathChar], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_module_path(module.as_handle())
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| {
+                    let mut end = v.as_ptr();
+                    while *end != 0 {
+                        end = end.offset(1);
+                    }
+                    let length = 1 + end.offset_from(v.as_ptr()) as usize;
+                    Ok(std::slice::from_raw_parts(v.as_ptr(), length))
+                },
+            )
+    }
+
+    #[inline]
+    unsafe fn get_load_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_load_dependencies(module.as_handle())
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| match v.is_empty() {
+                    true => Ok(<&[_]>::default()),
+                    false => Ok(std::slice::from_raw_parts(v.as_ptr(), v.len())),
+                },
+            )
+    }
+
+    #[inline]
+    unsafe fn get_runtime_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_runtime_dependencies(module.as_handle())
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| match v.is_empty() {
+                    true => Ok(<&[_]>::default()),
+                    false => Ok(std::slice::from_raw_parts(v.as_ptr(), v.len())),
+                },
+            )
+    }
+
+    #[inline]
+    unsafe fn get_exportable_interfaces<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_exportable_interfaces(module.as_handle())
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| match v.is_empty() {
+                    true => Ok(<&[_]>::default()),
+                    false => Ok(std::slice::from_raw_parts(v.as_ptr(), v.len())),
+                },
+            )
+    }
+
+    #[inline]
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader {
+        Self::InternalLoader::new(self._interface.as_ref().get_internal_interface())
+    }
+}
+
+/// Native module loader.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct NativeLoader<'loader> {
+    _interface: UnknownLoader<'loader>,
+}
+
+impl Deref for NativeLoader<'_> {
+    type Target = NonNullConst<ModuleLoaderInterface>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self._interface.deref()
+    }
+}
+
+impl DerefMut for NativeLoader<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self._interface.deref_mut()
+    }
+}
+
+impl ModuleLoaderABICompat for NativeLoader<'_> {}
+
+impl<'a> ModuleLoaderAPI<'a> for NativeLoader<'a> {
+    type InternalLoader = NativeLoaderInternal<'a>;
+
+    #[inline]
+    fn to_interface(&self) -> NonNullConst<ModuleLoaderInterface> {
+        self._interface.to_interface()
+    }
+
+    #[inline]
+    unsafe fn from_interface(interface: NonNullConst<ModuleLoaderInterface>) -> Self {
+        Self {
+            _interface: UnknownLoader::from_interface(interface),
+        }
+    }
+
+    #[inline]
+    unsafe fn from_void_ptr(interface: NonNullConst<c_void>) -> Self {
+        Self::from_interface(interface.cast())
+    }
+
+    #[inline]
+    unsafe fn add_module(
+        &mut self,
+        path: &impl AsRef<Path>,
+    ) -> Result<InternalModule<Owned>, Error> {
+        self._interface.add_module(path)
+    }
+
+    #[inline]
+    unsafe fn remove_module(&mut self, module: InternalModule<Owned>) -> Result<(), Error> {
+        self._interface.remove_module(module)
+    }
+
+    #[inline]
+    unsafe fn load<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface.load(module)
+    }
+
+    #[inline]
+    unsafe fn unload<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface.unload(module)
+    }
+
+    #[inline]
+    unsafe fn initialize<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface.initialize(module)
+    }
+
+    #[inline]
+    unsafe fn terminate<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        self._interface.terminate(module)
+    }
+
+    #[inline]
+    unsafe fn fetch_status<O>(&self, module: &InternalModule<O>) -> Result<ModuleStatus, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.fetch_status(module)
+    }
+
+    #[inline]
+    unsafe fn get_interface<'module, O, T>(
+        &self,
+        module: &'module InternalModule<O>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> T,
+    ) -> Result<Interface<'module, T>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.get_interface(module, interface, caster)
+    }
+
+    #[inline]
+    unsafe fn get_module_info<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module ModuleInfo, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.get_module_info(module)
+    }
+
+    #[inline]
+    unsafe fn get_module_path<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [OSPathChar], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.get_module_path(module)
+    }
+
+    #[inline]
+    unsafe fn get_load_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.get_load_dependencies(module)
+    }
+
+    #[inline]
+    unsafe fn get_runtime_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.get_runtime_dependencies(module)
+    }
+
+    #[inline]
+    unsafe fn get_exportable_interfaces<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface.get_exportable_interfaces(module)
+    }
+
+    #[inline]
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader {
+        Self::InternalLoader::from_void_ptr(*self._interface.get_internal_interface())
+    }
+}
+
+/// Native library loader internal interface.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct NativeLoaderInternal<'loader> {
+    _interface: NonNullConst<NativeModuleLoaderInterface>,
+    _phantom: PhantomData<&'loader ()>,
+}
+
+unsafe impl Send for NativeLoaderInternal<'_> {}
+unsafe impl Sync for NativeLoaderInternal<'_> {}
+
+impl Deref for NativeLoaderInternal<'_> {
+    type Target = NonNullConst<NativeModuleLoaderInterface>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self._interface
+    }
+}
+
+impl DerefMut for NativeLoaderInternal<'_> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self._interface
+    }
+}
+
+impl<'a> ModuleLoaderAPI<'a> for NativeLoaderInternal<'a> {
+    type InternalLoader = Self;
+
+    #[inline]
+    fn to_interface(&self) -> NonNullConst<ModuleLoaderInterface> {
+        // Safety: The pointer is always valid.
+        unsafe { self._interface.as_ref().loader }
+    }
+
+    #[inline]
+    unsafe fn from_interface(interface: NonNullConst<ModuleLoaderInterface>) -> Self {
+        NativeLoader::from_interface(interface).get_internal_interface()
+    }
+
+    #[inline]
+    unsafe fn from_void_ptr(interface: NonNullConst<c_void>) -> Self {
+        Self {
+            _interface: interface.cast(),
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    unsafe fn add_module(
+        &mut self,
+        path: &impl AsRef<Path>,
+    ) -> Result<InternalModule<Owned>, Error> {
+        NativeLoader::from_interface(self.to_interface()).add_module(path)
+    }
+
+    #[inline]
+    unsafe fn remove_module(&mut self, module: InternalModule<Owned>) -> Result<(), Error> {
+        NativeLoader::from_interface(self.to_interface()).remove_module(module)
+    }
+
+    #[inline]
+    unsafe fn load<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).load(module)
+    }
+
+    #[inline]
+    unsafe fn unload<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).unload(module)
+    }
+
+    #[inline]
+    unsafe fn initialize<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).initialize(module)
+    }
+
+    #[inline]
+    unsafe fn terminate<O>(&mut self, module: &mut InternalModule<O>) -> Result<(), Error>
+    where
+        O: MutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).terminate(module)
+    }
+
+    #[inline]
+    unsafe fn fetch_status<O>(&self, module: &InternalModule<O>) -> Result<ModuleStatus, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).fetch_status(module)
+    }
+
+    #[inline]
+    unsafe fn get_interface<'module, O, T>(
+        &self,
+        module: &'module InternalModule<O>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> T,
+    ) -> Result<Interface<'module, T>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).get_interface(module, interface, caster)
+    }
+
+    #[inline]
+    unsafe fn get_module_info<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module ModuleInfo, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).get_module_info(module)
+    }
+
+    #[inline]
+    unsafe fn get_module_path<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [OSPathChar], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).get_module_path(module)
+    }
+
+    #[inline]
+    unsafe fn get_load_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).get_load_dependencies(module)
+    }
+
+    #[inline]
+    unsafe fn get_runtime_dependencies<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).get_runtime_dependencies(module)
+    }
+
+    #[inline]
+    unsafe fn get_exportable_interfaces<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<&'module [InterfaceDescriptor], Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        NativeLoader::from_interface(self.to_interface()).get_exportable_interfaces(module)
+    }
+
+    #[inline]
+    unsafe fn get_internal_interface(&self) -> Self::InternalLoader {
+        *self
+    }
+}
+
+impl<'a> NativeLoaderInternal<'a> {
+    /// Fetches the native module handle.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `handle` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Native module handle.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeLoaderInternal] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_native_module<'module, O>(
+        &self,
+        module: &'module InternalModule<O>,
+    ) -> Result<NativeModuleInstance<'module, O>, Error>
+    where
+        O: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_native_module(module.as_handle())
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(NativeModuleInstance::new(v)),
+            )
+    }
+}

--- a/emf-core-base-rs/src/module/native_module.rs
+++ b/emf-core-base-rs/src/module/native_module.rs
@@ -1,0 +1,370 @@
+//! API of a native module.
+use crate::ffi::collections::NonNullConst;
+use crate::ffi::module::native_module::{
+    NativeModule as NativeModuleFFI, NativeModuleBinding,
+    NativeModuleInterface as NativeModuleInterfaceFFI,
+};
+use crate::ffi::CBaseBinding;
+use crate::module::{Error, Interface, InterfaceDescriptor, ModuleInfo};
+use crate::ownership::{
+    AccessIdentifier, BorrowImmutable, BorrowMutable, ImmutableAccessIdentifier,
+    MutableAccessIdentifier, Owned,
+};
+use crate::CBaseInterfaceInfo;
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+/// An instance from a native module.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct NativeModuleInstance<'a, O> {
+    _handle: Option<NonNull<NativeModuleFFI>>,
+    _phantom: PhantomData<&'a ()>,
+    _ownership: PhantomData<*const O>,
+}
+
+unsafe impl<O> Send for NativeModuleInstance<'_, O> {}
+unsafe impl<O> Sync for NativeModuleInstance<'_, O> {}
+
+impl<O> NativeModuleInstance<'_, O>
+where
+    O: AccessIdentifier,
+{
+    /// Construct a new instance from a handle.
+    ///
+    /// # Safety
+    ///
+    /// This function allows the creation of invalid handles
+    /// by bypassing lifetimes.
+    #[inline]
+    pub const unsafe fn new(handle: Option<NonNull<NativeModuleFFI>>) -> Self {
+        Self {
+            _handle: handle,
+            _phantom: PhantomData,
+            _ownership: PhantomData,
+        }
+    }
+
+    /// Fetches the internal handle.
+    #[inline]
+    pub const fn as_handle(&self) -> Option<NonNull<NativeModuleFFI>> {
+        self._handle
+    }
+}
+
+impl NativeModuleInstance<'_, Owned> {
+    /// Borrows the instance.
+    #[inline]
+    pub const fn as_borrowed(&self) -> NativeModuleInstance<'_, BorrowImmutable<'_>> {
+        unsafe { NativeModuleInstance::<BorrowImmutable<'_>>::new(self._handle) }
+    }
+
+    /// Borrows the instance mutably.
+    #[inline]
+    pub fn as_borrowed_mut(&mut self) -> NativeModuleInstance<'_, BorrowMutable<'_>> {
+        unsafe { NativeModuleInstance::<BorrowMutable<'_>>::new(self._handle) }
+    }
+}
+
+/// A native module.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct NativeModule<'a, O> {
+    _interface: NonNullConst<NativeModuleInterfaceFFI>,
+    _phantom: PhantomData<&'a ()>,
+    _ownership: PhantomData<*const O>,
+}
+
+unsafe impl<O> Send for NativeModule<'_, O> {}
+unsafe impl<O> Sync for NativeModule<'_, O> {}
+
+impl<'a, O> NativeModule<'a, O>
+where
+    O: MutableAccessIdentifier,
+{
+    /// Loads the module.
+    ///
+    /// # Failure
+    ///
+    /// The function can fail if some module invariant is not met.
+    ///
+    /// # Return
+    ///
+    /// Handle on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn load(
+        &mut self,
+        interface: &impl CBaseInterfaceInfo,
+    ) -> Result<NativeModuleInstance<'a, Owned>, Error> {
+        let internal = interface.internal_interface();
+        let interface_handle = internal.base_module();
+        let has_fn_fn = internal.fetch_has_function_fn();
+        let get_fn_fn = internal.fetch_get_function_fn();
+
+        self._interface
+            .into_mut()
+            .as_mut()
+            .load(interface_handle, has_fn_fn, get_fn_fn)
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(NativeModuleInstance::new(v)),
+            )
+    }
+
+    /// Unloads the module.
+    ///
+    /// # Failure
+    ///
+    /// The function can fail if some module invariant is not met or `instance` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn unload(
+        &mut self,
+        instance: NativeModuleInstance<'_, Owned>,
+    ) -> Result<(), Error> {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .unload(instance.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    /// Initializes the module.
+    ///
+    /// # Failure
+    ///
+    /// The function can fail if some module invariant is not met or `instance` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn initialize(
+        &mut self,
+        instance: &mut NativeModuleInstance<'_, Owned>,
+    ) -> Result<(), Error> {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .initialize(instance.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+
+    /// Terminates the module.
+    ///
+    /// # Failure
+    ///
+    /// The function can fail if some module invariant is not met or `instance` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Error on failure.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn terminate(
+        &mut self,
+        instance: &mut NativeModuleInstance<'_, Owned>,
+    ) -> Result<(), Error> {
+        self._interface
+            .into_mut()
+            .as_mut()
+            .terminate(instance.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |_v| Ok(()))
+    }
+}
+
+impl<'a, O> NativeModule<'a, O>
+where
+    O: ImmutableAccessIdentifier,
+{
+    /// Fetches an interface from the module.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `instance` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Interface on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function is not thread-safe and crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_interface<'instance, IO, T>(
+        &self,
+        instance: &'instance NativeModuleInstance<'instance, IO>,
+        interface: &InterfaceDescriptor,
+        caster: impl FnOnce(crate::ffi::module::Interface) -> T,
+    ) -> Result<Interface<'instance, T>, Error>
+    where
+        IO: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_interface(instance.as_handle(), NonNullConst::from(interface))
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| Ok(Interface::new(caster(v))),
+            )
+    }
+
+    /// Fetches the module info of the module.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `instance` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Module info on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function is not thread-safe and crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_module_info<'instance, IO>(
+        &self,
+        instance: &'instance NativeModuleInstance<'instance, IO>,
+    ) -> Result<&'instance ModuleInfo, Error>
+    where
+        IO: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_module_info(instance.as_handle())
+            .to_result()
+            .map_or_else(|e| Err(Error::FFIError(e)), |v| Ok(&*v.as_ptr()))
+    }
+
+    /// Fetches the load dependencies of the module.
+    ///
+    /// # Return
+    ///
+    /// Load dependencies.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_load_dependencies(&self) -> &'a [InterfaceDescriptor] {
+        let span = self._interface.as_ref().get_load_dependencies();
+        if span.is_empty() {
+            <&[_]>::default()
+        } else {
+            std::slice::from_raw_parts(span.as_ptr(), span.len())
+        }
+    }
+
+    /// Fetches the runtime dependencies of the module.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `instance` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Runtime dependencies on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function is not thread-safe and crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_runtime_dependencies<'instance, IO>(
+        &self,
+        instance: &'instance NativeModuleInstance<'instance, IO>,
+    ) -> Result<&'instance [InterfaceDescriptor], Error>
+    where
+        IO: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_runtime_dependencies(instance.as_handle())
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| {
+                    if v.is_empty() {
+                        Ok(<&[_]>::default())
+                    } else {
+                        Ok(std::slice::from_raw_parts(v.as_ptr(), v.len()))
+                    }
+                },
+            )
+    }
+
+    /// Fetches the exportable interfaces of the module.
+    ///
+    /// # Failure
+    ///
+    /// The function fails if `instance` is invalid.
+    ///
+    /// # Return
+    ///
+    /// Exportable interfaces on success, error otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function is not thread-safe and crosses the ffi boundary.
+    /// Direct usage of a [NativeModule] may break some invariants
+    /// of the module api, if not handled with care.
+    #[inline]
+    pub unsafe fn get_exportable_interfaces<'instance, IO>(
+        &self,
+        instance: &'instance NativeModuleInstance<'instance, IO>,
+    ) -> Result<&'instance [InterfaceDescriptor], Error>
+    where
+        IO: ImmutableAccessIdentifier,
+    {
+        self._interface
+            .as_ref()
+            .get_exportable_interfaces(instance.as_handle())
+            .to_result()
+            .map_or_else(
+                |e| Err(Error::FFIError(e)),
+                |v| {
+                    if v.is_empty() {
+                        Ok(<&[_]>::default())
+                    } else {
+                        Ok(std::slice::from_raw_parts(v.as_ptr(), v.len()))
+                    }
+                },
+            )
+    }
+}

--- a/emf-core-base-rs/src/ownership.rs
+++ b/emf-core-base-rs/src/ownership.rs
@@ -1,0 +1,42 @@
+//! Types and traits for denoting ownership.
+use std::marker::PhantomData;
+
+/// Trait for identifying ownership identifiers
+pub trait AccessIdentifier: private::Sealed {}
+
+/// Trait for identifying ownership identifiers with unique access semantics.
+pub trait MutableAccessIdentifier: AccessIdentifier {}
+
+/// Trait for identifying ownership identifiers with immutable access semantics.
+pub trait ImmutableAccessIdentifier: AccessIdentifier {}
+
+/// Identifier for `owned` types.
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Owned {}
+
+/// Identifier for `mutably borrowed` types.
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub struct BorrowMutable<'a>(PhantomData<&'a ()>);
+
+/// Identifier for `borrowed` types.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct BorrowImmutable<'a>(PhantomData<&'a ()>);
+
+impl AccessIdentifier for Owned {}
+impl AccessIdentifier for BorrowMutable<'_> {}
+impl AccessIdentifier for BorrowImmutable<'_> {}
+
+impl MutableAccessIdentifier for Owned {}
+impl MutableAccessIdentifier for BorrowMutable<'_> {}
+
+impl ImmutableAccessIdentifier for Owned {}
+impl ImmutableAccessIdentifier for BorrowMutable<'_> {}
+impl ImmutableAccessIdentifier for BorrowImmutable<'_> {}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for super::Owned {}
+    impl Sealed for super::BorrowMutable<'_> {}
+    impl Sealed for super::BorrowImmutable<'_> {}
+}

--- a/emf-core-base-rs/src/sys.rs
+++ b/emf-core-base-rs/src/sys.rs
@@ -1,0 +1,131 @@
+//! Sys api.
+//!
+//! The sys api is exposed by the [SysAPI] trait.
+use crate::ffi::collections::NonNullConst;
+use crate::ffi::sys::api::SysBinding;
+use crate::ffi::Bool;
+use crate::fn_caster::FnCaster;
+use crate::sys::sync_handler::SyncHandlerAPI;
+use std::ffi::CStr;
+
+pub mod sync_handler;
+
+/// Minimal sys api.
+pub trait SysAPIMin<'interface> {
+    /// Execution of the program is stopped abruptly. The error may be logged.
+    fn panic(&self, error: Option<impl AsRef<CStr>>) -> !;
+
+    /// Checks if a function is implemented.
+    ///
+    /// # Return
+    ///
+    /// Returns [true] if the function exists, [false] otherwise.
+    fn has_function<U>(&self) -> bool
+    where
+        U: FnCaster;
+
+    /// Fetches a function from the interface.
+    ///
+    /// # Return
+    ///
+    /// Function casted to the appropriate type.
+    fn get_function<U>(&self, caster: &U) -> Option<<U as FnCaster>::Type>
+    where
+        U: FnCaster;
+}
+
+/// Idiomatic sys api.
+pub trait SysAPI<'interface>: SysAPIMin<'interface> {
+    /// Sends a termination signal.
+    fn shutdown(&mut self) -> !;
+
+    /// Fetches the active synchronization handler.
+    ///
+    /// # Return
+    ///
+    /// The active synchronization handler.
+    fn get_sync_handler<U>(&self) -> <U as SyncHandlerAPI<'interface>>::Handler
+    where
+        U: SyncHandlerAPI<'interface>;
+
+    /// Sets a new synchronization handler.
+    ///
+    /// The default synchronization handler is used, if `handler` is [Option::None].
+    ///
+    /// # Uses
+    ///
+    /// This function can be used by modules, that want to provide a more complex
+    /// synchronization mechanism than the one presented by the default handler.
+    ///
+    /// # Swapping
+    ///
+    /// The swapping occurs in three steps:
+    ///
+    /// 1. The new synchronization handler is locked.
+    /// 2. The new synchronization handler is set as the active synchronization handler.
+    /// 3. The old synchronization handler is unlocked.
+    ///
+    /// # Safety
+    ///
+    /// Changing the synchronization handler may break some modules,
+    /// if they depend on a specific synchronization handler.
+    unsafe fn set_sync_handler(&mut self, handler: Option<&impl SyncHandlerAPI<'interface>>);
+}
+
+impl<'interface, T> SysAPIMin<'interface> for T
+where
+    T: SysBinding,
+{
+    #[inline]
+    fn panic(&self, error: Option<impl AsRef<CStr>>) -> ! {
+        unsafe {
+            <T as SysBinding>::panic(
+                self,
+                error.map(|err| NonNullConst::from(err.as_ref().to_bytes_with_nul())),
+            )
+        }
+    }
+
+    #[inline]
+    fn has_function<U>(&self) -> bool
+    where
+        U: FnCaster,
+    {
+        unsafe { <T as SysBinding>::has_function(self, U::ID) == Bool::True }
+    }
+
+    #[inline]
+    fn get_function<U>(&self, caster: &U) -> Option<<U as FnCaster>::Type>
+    where
+        U: FnCaster,
+    {
+        unsafe {
+            <T as SysBinding>::get_function(self, U::ID)
+                .to_option()
+                .map(|func| caster.cast(func))
+        }
+    }
+}
+
+impl<'interface, T> SysAPI<'interface> for T
+where
+    T: SysBinding,
+{
+    #[inline]
+    fn shutdown(&mut self) -> ! {
+        unsafe { <T as SysBinding>::shutdown(self) }
+    }
+
+    #[inline]
+    fn get_sync_handler<U>(&self) -> <U as SyncHandlerAPI<'interface>>::Handler
+    where
+        U: SyncHandlerAPI<'interface>,
+    {
+        unsafe { U::from_interface(<T as SysBinding>::get_sync_handler(self)) }
+    }
+
+    #[inline]
+    unsafe fn set_sync_handler(&mut self, handler: Option<&impl SyncHandlerAPI<'interface>>) {
+        <T as SysBinding>::set_sync_handler(self, handler.map(|handler| handler.to_interface()))
+    }
+}

--- a/emf-core-base-rs/src/sys/sync_handler.rs
+++ b/emf-core-base-rs/src/sys/sync_handler.rs
@@ -1,0 +1,94 @@
+//! API of a sync handler.
+use crate::ffi::collections::NonNullConst;
+use crate::ffi::sys::sync_handler::{SyncHandlerBinding, SyncHandlerInterface};
+use crate::ffi::Bool;
+
+/// A borrowed sync handler.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub struct SyncHandler<'a> {
+    handler: &'a SyncHandlerInterface,
+}
+
+/// The API of a sync handler.
+pub trait SyncHandlerAPI<'a> {
+    /// Type of the sync handler.
+    type Handler;
+
+    /// Fetches a pointer that can be used with the interface.
+    fn to_interface(&self) -> NonNullConst<SyncHandlerInterface>;
+
+    /// Construct a new instance with the pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function should not be used directly.
+    unsafe fn from_interface(handler: NonNullConst<SyncHandlerInterface>) -> Self::Handler;
+
+    /// Locks the synchronisation handler.
+    ///
+    /// The calling thread is stalled until the lock can be acquired.
+    /// Only one thread can hold the lock at a time.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [SyncHandlerAPI] may break some invariants
+    /// of the sys api, if not handled with care.
+    unsafe fn lock(&self);
+
+    /// Tries to lock the synchronisation handler.
+    ///
+    /// The function fails if another thread already holds the lock.
+    ///
+    /// # Return
+    ///
+    /// [true] on success and [false] otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Direct usage of a [SyncHandlerAPI] may break some invariants
+    /// of the sys api, if not handled with care.
+    unsafe fn try_lock(&self) -> bool;
+
+    /// Unlocks the synchronisation handler.
+    ///
+    /// # Safety
+    ///
+    /// The function crosses the ffi boundary.
+    /// Trying to call this function without prior locking is undefined behaviour.
+    /// Direct usage of a [SyncHandlerAPI] may break some invariants
+    /// of the sys api, if not handled with care.
+    unsafe fn unlock(&self);
+}
+
+impl SyncHandlerAPI<'_> for SyncHandler<'_> {
+    type Handler = Self;
+
+    #[inline]
+    fn to_interface(&self) -> NonNullConst<SyncHandlerInterface> {
+        NonNullConst::from(self.handler)
+    }
+
+    #[inline]
+    unsafe fn from_interface(handler: NonNullConst<SyncHandlerInterface>) -> Self::Handler {
+        Self {
+            handler: &*handler.as_ptr(),
+        }
+    }
+
+    #[inline]
+    unsafe fn lock(&self) {
+        self.handler.lock()
+    }
+
+    #[inline]
+    unsafe fn try_lock(&self) -> bool {
+        self.handler.try_lock() == Bool::True
+    }
+
+    #[inline]
+    unsafe fn unlock(&self) {
+        self.handler.unlock()
+    }
+}

--- a/emf-core-base-rs/src/to_os_path_buff.rs
+++ b/emf-core-base-rs/src/to_os_path_buff.rs
@@ -1,0 +1,37 @@
+use crate::ffi::library::OSPathChar;
+use std::ffi::OsStr;
+
+/// Trait for encoding into the platforms preferred encoding.
+pub trait ToOsPathBuff {
+    /// Creates an owned buffer with the platforms preferred encoding.
+    fn to_os_path_buff(&self) -> Vec<OSPathChar>;
+
+    /// Like `to_os_path_buff`, but with an additional null terminator.
+    fn to_os_path_buff_null(&self) -> Vec<OSPathChar>;
+}
+
+impl<T> ToOsPathBuff for T
+where
+    T: AsRef<OsStr>,
+{
+    #[inline]
+    #[cfg(windows)]
+    fn to_os_path_buff(&self) -> Vec<OSPathChar> {
+        use std::os::windows::ffi::OsStrExt;
+        self.as_ref().encode_wide().collect()
+    }
+
+    #[inline]
+    #[cfg(unix)]
+    fn to_os_path_buff(&self) -> Vec<OSPathChar> {
+        use std::os::unix::ffi::OsStrExt;
+        Vec::from(self.as_ref().as_bytes())
+    }
+
+    #[inline]
+    fn to_os_path_buff_null(&self) -> Vec<OSPathChar> {
+        let mut buff = self.to_os_path_buff();
+        buff.push(0);
+        buff
+    }
+}

--- a/emf-core-base-rs/src/version.rs
+++ b/emf-core-base-rs/src/version.rs
@@ -1,0 +1,357 @@
+//! Version api.
+//!
+//! The version api is exposed by the [VersionAPI] trait.
+use crate::ffi::collections::{ConstSpan, MutSpan, NonNullConst};
+use crate::ffi::version::api::VersionBinding;
+use crate::ffi::Bool;
+use std::cmp::Ordering;
+use std::ptr::NonNull;
+
+pub use crate::ffi::version::{Error, ReleaseType, Version};
+
+/// Trait for providing access to the version api.
+pub trait VersionAPI {
+    /// Constructs a new version.
+    ///
+    /// Constructs a new version with `major`, `minor` and `patch` and sets the rest to `0`.
+    ///
+    /// # Return
+    ///
+    /// Constructed version.
+    fn new_short(&self, major: i32, minor: i32, patch: i32) -> Version;
+
+    /// Constructs a new version.
+    ///
+    /// Constructs a new version with `major`, `minor`, `patch`, `release_type` and
+    /// `release_number` and sets the rest to `0`.
+    ///
+    /// # Return
+    ///
+    /// Constructed version.
+    fn new_long(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+    ) -> Version;
+
+    /// Constructs a new version.
+    ///
+    /// Constructs a new version with `major`, `minor`, `patch`, `release_type`,
+    /// `release_number` and `build`.
+    ///
+    /// # Return
+    ///
+    /// Constructed version.
+    fn new_full(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+        build: i64,
+    ) -> Version;
+
+    /// Constructs a version from a string.
+    ///
+    /// # Failure
+    ///
+    /// Fails if `string_is_valid(buffer) == false`.
+    ///
+    /// # Return
+    ///
+    /// Constructed version.
+    fn from_string(&self, buffer: impl AsRef<str>) -> Result<Version, Error>;
+
+    /// Computes the length of the short version string.
+    ///
+    /// # Return
+    ///
+    /// Length of the string.
+    fn string_length_short(&self, version: &Version) -> usize;
+
+    /// Computes the length of the long version string.
+    ///
+    /// # Return
+    ///
+    /// Length of the string.
+    fn string_length_long(&self, version: &Version) -> usize;
+
+    /// Computes the length of the full version string.
+    ///
+    /// # Return
+    ///
+    /// Length of the string.
+    fn string_length_full(&self, version: &Version) -> usize;
+
+    /// Represents the version as a short string.
+    ///
+    /// # Failure
+    ///
+    /// This function fails if `buffer.len() < string_length_short(version)`.
+    ///
+    /// # Return
+    ///
+    /// Number of written characters on success, error otherwise.
+    fn as_string_short(&self, version: &Version, buffer: impl AsMut<str>) -> Result<usize, Error>;
+
+    /// Represents the version as a long string.
+    ///
+    /// # Failure
+    ///
+    /// This function fails if `buffer.len() < string_length_long(version)`.
+    ///
+    /// # Return
+    ///
+    /// Number of written characters on success, error otherwise.
+    fn as_string_long(&self, version: &Version, buffer: impl AsMut<str>) -> Result<usize, Error>;
+
+    /// Represents the version as a full string.
+    ///
+    /// # Failure
+    ///
+    /// This function fails if `buffer.len() < string_length_full(version)`.
+    ///
+    /// # Return
+    ///
+    /// Number of written characters on success, error otherwise.
+    fn as_string_full(&self, version: &Version, buffer: impl AsMut<str>) -> Result<usize, Error>;
+
+    /// Checks whether the version string is valid.
+    ///
+    /// # Return
+    ///
+    /// [true] if the string is valid, [false] otherwise.
+    fn string_is_valid(&self, version_string: impl AsRef<str>) -> bool;
+
+    /// Compares two versions.
+    ///
+    /// Compares two version, disregarding their build number.
+    ///
+    /// # Return
+    ///
+    /// Order of the versions.
+    fn compare(&self, lhs: &Version, rhs: &Version) -> Ordering;
+
+    /// Compares two versions.
+    ///
+    /// Compares two version, disregarding their build number and release type.
+    ///
+    /// # Return
+    ///
+    /// Order of the versions.
+    fn compare_weak(&self, lhs: &Version, rhs: &Version) -> Ordering;
+
+    /// Compares two versions.
+    ///
+    /// # Return
+    ///
+    /// Order of the versions.
+    fn compare_strong(&self, lhs: &Version, rhs: &Version) -> Ordering;
+
+    /// Checks for compatibility of two versions.
+    ///
+    /// Two compatible versions can be used interchangeably.
+    ///
+    /// # Note
+    ///
+    /// This function is not commutative.
+    ///
+    /// # Return
+    ///
+    /// [true] if the versions are compatible, [false] otherwise.
+    fn is_compatible(&self, lhs: &Version, rhs: &Version) -> bool;
+}
+
+impl<T> VersionAPI for T
+where
+    T: VersionBinding,
+{
+    #[inline]
+    fn new_short(&self, major: i32, minor: i32, patch: i32) -> Version {
+        unsafe { <T as VersionBinding>::new_short(self, major, minor, patch) }
+    }
+
+    #[inline]
+    fn new_long(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+    ) -> Version {
+        unsafe {
+            <T as VersionBinding>::new_long(self, major, minor, patch, release_type, release_number)
+        }
+    }
+
+    #[inline]
+    fn new_full(
+        &self,
+        major: i32,
+        minor: i32,
+        patch: i32,
+        release_type: ReleaseType,
+        release_number: i8,
+        build: i64,
+    ) -> Version {
+        unsafe {
+            <T as VersionBinding>::new_full(
+                self,
+                major,
+                minor,
+                patch,
+                release_type,
+                release_number,
+                build,
+            )
+        }
+    }
+
+    #[inline]
+    fn from_string(&self, buffer: impl AsRef<str>) -> Result<Version, Error> {
+        unsafe {
+            <T as VersionBinding>::from_string(
+                self,
+                NonNullConst::from(&ConstSpan::from(buffer.as_ref())),
+            )
+            .to_result()
+        }
+    }
+
+    #[inline]
+    fn string_length_short(&self, version: &Version) -> usize {
+        unsafe { <T as VersionBinding>::string_length_short(self, NonNullConst::from(version)) }
+    }
+
+    #[inline]
+    fn string_length_long(&self, version: &Version) -> usize {
+        unsafe { <T as VersionBinding>::string_length_long(self, NonNullConst::from(version)) }
+    }
+
+    #[inline]
+    fn string_length_full(&self, version: &Version) -> usize {
+        unsafe { <T as VersionBinding>::string_length_full(self, NonNullConst::from(version)) }
+    }
+
+    #[inline]
+    fn as_string_short(
+        &self,
+        version: &Version,
+        mut buffer: impl AsMut<str>,
+    ) -> Result<usize, Error> {
+        unsafe {
+            <T as VersionBinding>::as_string_short(
+                self,
+                NonNullConst::from(version),
+                NonNull::from(&MutSpan::from(buffer.as_mut())),
+            )
+            .to_result()
+        }
+    }
+
+    #[inline]
+    fn as_string_long(
+        &self,
+        version: &Version,
+        mut buffer: impl AsMut<str>,
+    ) -> Result<usize, Error> {
+        unsafe {
+            <T as VersionBinding>::as_string_long(
+                self,
+                NonNullConst::from(version),
+                NonNull::from(&MutSpan::from(buffer.as_mut())),
+            )
+            .to_result()
+        }
+    }
+
+    #[inline]
+    fn as_string_full(
+        &self,
+        version: &Version,
+        mut buffer: impl AsMut<str>,
+    ) -> Result<usize, Error> {
+        unsafe {
+            <T as VersionBinding>::as_string_full(
+                self,
+                NonNullConst::from(version),
+                NonNull::from(&MutSpan::from(buffer.as_mut())),
+            )
+            .to_result()
+        }
+    }
+
+    #[inline]
+    fn string_is_valid(&self, version_string: impl AsRef<str>) -> bool {
+        unsafe {
+            <T as VersionBinding>::string_is_valid(
+                self,
+                NonNullConst::from(&ConstSpan::from(version_string.as_ref())),
+            ) == Bool::True
+        }
+    }
+
+    #[inline]
+    fn compare(&self, lhs: &Version, rhs: &Version) -> Ordering {
+        unsafe {
+            match <T as VersionBinding>::compare(
+                self,
+                NonNullConst::from(lhs),
+                NonNullConst::from(rhs),
+            ) {
+                -1 => Ordering::Greater,
+                0 => Ordering::Equal,
+                1 => Ordering::Less,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[inline]
+    fn compare_weak(&self, lhs: &Version, rhs: &Version) -> Ordering {
+        unsafe {
+            match <T as VersionBinding>::compare_weak(
+                self,
+                NonNullConst::from(lhs),
+                NonNullConst::from(rhs),
+            ) {
+                -1 => Ordering::Greater,
+                0 => Ordering::Equal,
+                1 => Ordering::Less,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[inline]
+    fn compare_strong(&self, lhs: &Version, rhs: &Version) -> Ordering {
+        unsafe {
+            match <T as VersionBinding>::compare_strong(
+                self,
+                NonNullConst::from(lhs),
+                NonNullConst::from(rhs),
+            ) {
+                -1 => Ordering::Greater,
+                0 => Ordering::Equal,
+                1 => Ordering::Less,
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[inline]
+    fn is_compatible(&self, lhs: &Version, rhs: &Version) -> bool {
+        unsafe {
+            <T as VersionBinding>::is_compatible(
+                self,
+                NonNullConst::from(lhs),
+                NonNullConst::from(rhs),
+            ) == Bool::True
+        }
+    }
+}


### PR DESCRIPTION
This pull requests implements an idiomatic rust wrapper of the `emf-core-base-rs-ffi` crate, called `emf-core-base-rs`.