### PR TITLE
Use Pin for the loader registration

### DIFF
--- a/emf-core-base-rs/src/global/library.rs
+++ b/emf-core-base-rs/src/global/library.rs
@@ -38,6 +38,7 @@ use crate::ownership::{BorrowMutable, ImmutableAccessIdentifier, MutableAccessId
 use crate::Error;
 use std::ffi::{c_void, CStr};
 use std::path::Path;
+use std::pin::Pin;
 
 /// Registers a new loader.
 ///
@@ -52,14 +53,14 @@ use std::path::Path;
 ///
 /// Handle on success, error otherwise.
 #[inline]
-pub fn register_loader<'loader, L, LT, T>(
+pub fn register_loader<L, LT, T>(
     _token: &mut LockToken<L>,
-    loader: &'loader LT,
+    loader: Pin<&'static LT>,
     lib_type: impl AsRef<str>,
 ) -> Result<Loader<'static, Owned>, Error<Owned>>
 where
     T: LibraryLoaderAPI<'static> + LibraryLoaderABICompat,
-    LibraryLoader<T, Owned>: From<&'loader LT>,
+    LibraryLoader<T, Owned>: From<&'static LT>,
 {
     LibraryAPI::register_loader(get_mut_interface(), loader, lib_type)
 }

--- a/emf-core-base-rs/src/global/module.rs
+++ b/emf-core-base-rs/src/global/module.rs
@@ -39,6 +39,7 @@ use crate::ownership::{
 };
 use crate::Error;
 use std::path::Path;
+use std::pin::Pin;
 
 /// Registers a new module loader.
 ///
@@ -52,14 +53,14 @@ use std::path::Path;
 ///
 /// Handle on success, error otherwise.
 #[inline]
-pub fn register_loader<'loader, LT, L, T>(
+pub fn register_loader<LT, L, T>(
     _token: &mut LockToken<T>,
-    loader: &'loader LT,
+    loader: Pin<&'static LT>,
     mod_type: impl AsRef<str>,
 ) -> Result<Loader<'static, Owned>, Error<Owned>>
 where
     L: ModuleLoaderAPI<'static> + ModuleLoaderABICompat,
-    ModuleLoader<L, Owned>: From<&'loader LT>,
+    ModuleLoader<L, Owned>: From<&'static LT>,
 {
     ModuleAPI::register_loader(get_mut_interface(), loader, mod_type)
 }


### PR DESCRIPTION
The previous API for registering loaders is unsound, as it relies on the assumption that the loader lives longer than the interface and won't be moved once registered. Those assumptions were not checked by the type system.